### PR TITLE
Zelnode update in lastest version

### DIFF
--- a/src/deprecation.h
+++ b/src/deprecation.h
@@ -10,7 +10,7 @@
 // * Shut down 16 weeks' worth of blocks after the estimated release block height.
 // * A warning is shown during the 2 weeks' worth of blocks prior to shut down.
 
-static const int APPROX_RELEASE_HEIGHT = 250000;
+static const int APPROX_RELEASE_HEIGHT = 350000;
 static const int WEEKS_UNTIL_DEPRECATION = 26;
 static const int DEPRECATION_HEIGHT = APPROX_RELEASE_HEIGHT + (WEEKS_UNTIL_DEPRECATION * 7 * 24 * 30);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3787,8 +3787,8 @@ bool CheckBlock(const CBlock& block, CValidationState& state,
         // Because we might not have enough data to tell if the block is indeed valid, Issue an initial reject message
         if (nHeight != 0 && !IsInitialBlockDownload()) {
             if (!IsBlockPayeeValid(block, nHeight)) {
-                return state.DoS(0, error("%s : Couldn't find zelnode payment", __func__),
-                                 REJECT_INVALID, "bad-cb-payee");
+                LogPrint("zelnode", "%s : Couldn't find zelnode payment", __func__);
+                return state.DoS(0, false, REJECT_INVALID, "bad-cb-payee");
             }
         } else {
             if (fDebug)
@@ -4045,7 +4045,11 @@ bool ProcessNewBlock(CValidationState &state, CNode* pfrom, CBlock* pblock, bool
         bool fRequested = MarkBlockAsReceived(pblock->GetHash());
         fRequested |= fForceProcessing;
         if (!checked) {
-            return error("%s: CheckBlock FAILED", __func__);
+            if (state.GetRejectReason() == "bad-cb-payee") {
+                LogPrint("zelnode", "%s - Error - failed block payee check\n", __func__);
+                return false;
+            }
+            return error("%s: CheckBlock FAILED %s", __func__, state.GetRejectReason());
         }
 
         // Store to disk

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
+// Copyright (c) 2019 The Zelcash Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -21,6 +22,7 @@
 #include "txmempool.h"
 #include "util.h"
 #include "validationinterface.h"
+#include "zelnode/spork.h"
 #ifdef ENABLE_WALLET
 #include "wallet/wallet.h"
 #endif
@@ -567,6 +569,11 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
 
     if (IsInitialBlockDownload())
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Zelcash is downloading blocks...");
+
+    // when enforcement is on we need information about a zelnode payee or otherwise our block is going to be orphaned by the network
+    if (IsSporkActive(SPORK_1_ZELNODE_PAYMENT_ENFORCEMENT)
+        && !zelnodeSync.IsZelnodeWinnersSynced())
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Zelcash is downloading zelnode winners...");
 
     static unsigned int nTransactionsUpdatedLast;
 

--- a/src/rpc/zelnode.cpp
+++ b/src/rpc/zelnode.cpp
@@ -315,6 +315,7 @@ UniValue znsync(const UniValue& params, bool fHelp)
                 "  \"countZelnodeWinner\": n,    (numeric) Number of ZN winner messages (local)\n"
                 "  \"RequestedZelnodeAssets\": n, (numeric) Status code of last sync phase\n"
                 "  \"RequestedZelnodeAttempt\": n, (numeric) Status code of last sync attempt\n"
+                "  \"Status\": xxxx,               (string) Status as a string \n"
                 "}\n"
 
                 "\nResult ('reset' mode):\n"
@@ -338,6 +339,7 @@ UniValue znsync(const UniValue& params, bool fHelp)
         obj.push_back(Pair("countZelnodeWinner", zelnodeSync.countZelnodeWinner));
         obj.push_back(Pair("RequestedZelnodeAssets", zelnodeSync.RequestedZelnodeAssets));
         obj.push_back(Pair("RequestedZelnodeAttempt", zelnodeSync.RequestedZelnodeAttempt));
+        obj.push_back(Pair("Status", zelnodeSync.GetSyncStatus()));
 
         return obj;
     }

--- a/src/zelnode/spork.cpp
+++ b/src/zelnode/spork.cpp
@@ -59,7 +59,7 @@ void LoadSporksFromDB()
 void ProcessSpork(CNode* pfrom, std::string& strCommand, CDataStream& vRecv)
 {
     if (strCommand == "spork") {
-        LogPrintf("ProcessSpork::spork\n");
+        if (fDebug) LogPrintf("%s : spork\n", __func__);
         CDataStream vMsg(vRecv);
         CSporkMessage spork;
         vRecv >> spork;

--- a/src/zelnode/zelnodesync.cpp
+++ b/src/zelnode/zelnodesync.cpp
@@ -50,9 +50,7 @@ bool ZelnodeSync::IsBlockchainSynced()
     CBlockIndex* pindex = chainActive.Tip();
     if (pindex == NULL) return false;
 
-
-    // TODO, remove this constraint after testing on TESTNET which doesn't have a solid block schedule
-    if (pindex->nTime + 60 * 60 * 48 < GetTime())
+    if (pindex->nTime + 60 * 60 < GetTime())
         return false;
 
     fBlockchainSynced = true;
@@ -74,7 +72,7 @@ void ZelnodeSync::Reset()
     countZelnodeWinner = 0;
     RequestedZelnodeAssets = ZELNODE_SYNC_INITIAL;
     RequestedZelnodeAttempt = 0;
-    nAssetSyncStarted = GetTime();
+    nTimeAssetSyncStarted = GetTime();
 }
 
 void ZelnodeSync::AddedZelnodeList(uint256 hash)
@@ -106,35 +104,41 @@ void ZelnodeSync::AddedZelnodeWinner(uint256 hash)
 void ZelnodeSync::GetNextAsset()
 {
     switch (RequestedZelnodeAssets) {
-        case (ZELNODE_SYNC_INITIAL):
         case (ZELNODE_SYNC_FAILED): // should never be used here actually, use Reset() instead
             ClearFulfilledRequest();
+            RequestedZelnodeAssets = ZELNODE_SYNC_INITIAL;
+            LogPrintf("ZelnodeSync::GetNextAsset -- Starting %s\n", GetSyncStatus());
+            break;
+        case(ZELNODE_SYNC_INITIAL):
             RequestedZelnodeAssets = ZELNODE_SYNC_SPORKS;
+            LogPrintf("ZelnodeSync::GetNextAsset -- Starting %s\n", GetSyncStatus());
             break;
         case (ZELNODE_SYNC_SPORKS):
             RequestedZelnodeAssets = ZELNODE_SYNC_LIST;
+            LogPrintf("ZelnodeSync::GetNextAsset -- Starting %s\n", GetSyncStatus());
             break;
         case (ZELNODE_SYNC_LIST):
             RequestedZelnodeAssets = ZELNODE_SYNC_MNW;
+            LogPrintf("ZelnodeSync::GetNextAsset -- Starting %s\n", GetSyncStatus());
             break;
         case (ZELNODE_SYNC_MNW):
             RequestedZelnodeAssets = ZELNODE_SYNC_FINISHED;
-            LogPrintf("%s - Sync has finished\n", __func__);
+            LogPrintf("ZelnodeSync - Sync has finished\n");
             break;
     }
     RequestedZelnodeAttempt = 0;
-    nAssetSyncStarted = GetTime();
+    nTimeAssetSyncStarted = GetTime();
 }
 
 std::string ZelnodeSync::GetSyncStatus()
 {
     switch (zelnodeSync.RequestedZelnodeAssets) {
         case ZELNODE_SYNC_INITIAL:
-            return _("Synchronization pending...");
+            return _("Synchronization initializing...");
         case ZELNODE_SYNC_SPORKS:
             return _("Synchronizing sporks...");
         case ZELNODE_SYNC_LIST:
-            return _("Synchronizing zelnodes...");
+            return _("Synchronizing zelnode list...");
         case ZELNODE_SYNC_MNW:
             return _("Synchronizing zelnode winners...");
         case ZELNODE_SYNC_FAILED:
@@ -207,7 +211,7 @@ void ZelnodeSync::Process()
         return;
     }
 
-    LogPrint("zelnode", "%s - tick %d RequestedZelnodeAssets %d\n", __func__, tick, RequestedZelnodeAssets);
+    LogPrintf("%s::Process -- Tick %d nCurrentAsset %d nTriedPeerCount %d nSyncProgress %f\n", __func__, tick, RequestedZelnodeAssets);
 
     if (RequestedZelnodeAssets == ZELNODE_SYNC_INITIAL) GetNextAsset();
 
@@ -220,6 +224,7 @@ void ZelnodeSync::Process()
         return;
 
     for (CNode* pnode : vNodes) {
+
         if (Params().NetworkID() == CBaseChainParams::REGTEST) {
             if (RequestedZelnodeAttempt <= 2) {
                 pnode->PushMessage("getsporks"); //get current network sporks
@@ -262,9 +267,9 @@ void ZelnodeSync::Process()
 
                 // timeout
                 if (lastZelnodeList == 0 &&
-                    (RequestedZelnodeAttempt >= ZELNODE_SYNC_THRESHOLD * 3 || GetTime() - nAssetSyncStarted > ZELNODE_SYNC_TIMEOUT * 5)) {
+                    (RequestedZelnodeAttempt >= ZELNODE_SYNC_THRESHOLD * 3 || GetTime() - nTimeAssetSyncStarted > ZELNODE_SYNC_TIMEOUT * 5)) {
                     if (IsSporkActive(SPORK_1_ZELNODE_PAYMENT_ENFORCEMENT)) {
-                        LogPrintf("%s - ERROR - Sync has failed, will retry later\n", __func__);
+                        LogPrintf("%s - ERROR - Syncing zelnode list has failed, will retry later\n", __func__);
                         RequestedZelnodeAssets = ZELNODE_SYNC_FAILED;
                         RequestedZelnodeAttempt = 0;
                         lastFailure = GetTime();
@@ -293,9 +298,9 @@ void ZelnodeSync::Process()
 
                 // timeout
                 if (lastZelnodeWinner == 0 &&
-                    (RequestedZelnodeAttempt >= ZELNODE_SYNC_THRESHOLD * 3 || GetTime() - nAssetSyncStarted > ZELNODE_SYNC_TIMEOUT * 5)) {
+                    (RequestedZelnodeAttempt >= ZELNODE_SYNC_THRESHOLD * 3 || GetTime() - nTimeAssetSyncStarted > ZELNODE_SYNC_TIMEOUT * 5)) {
                     if (IsSporkActive(SPORK_1_ZELNODE_PAYMENT_ENFORCEMENT)) {
-                        LogPrintf("%s - ERROR - Sync has failed, will retry later\n", __func__);
+                        LogPrintf("%s - ERROR - Syncing zelnode winners has failed, will retry later\n", __func__);
                         RequestedZelnodeAssets = ZELNODE_SYNC_FAILED;
                         RequestedZelnodeAttempt = 0;
                         lastFailure = GetTime();

--- a/src/zelnode/zelnodesync.cpp
+++ b/src/zelnode/zelnodesync.cpp
@@ -211,7 +211,7 @@ void ZelnodeSync::Process()
         return;
     }
 
-    LogPrintf("%s::Process -- Tick %d nCurrentAsset %d nTriedPeerCount %d nSyncProgress %f\n", __func__, tick, RequestedZelnodeAssets);
+    LogPrintf("%s::Process -- Tick %d nCurrentAsset %d\n", __func__, tick, RequestedZelnodeAssets);
 
     if (RequestedZelnodeAssets == ZELNODE_SYNC_INITIAL) GetNextAsset();
 

--- a/src/zelnode/zelnodesync.h
+++ b/src/zelnode/zelnodesync.h
@@ -10,11 +10,11 @@
 #include <map>
 #include "uint256.h"
 
+#define ZELNODE_SYNC_FAILED -1
 #define ZELNODE_SYNC_INITIAL 0
 #define ZELNODE_SYNC_SPORKS 1
 #define ZELNODE_SYNC_LIST 2
 #define ZELNODE_SYNC_MNW 3
-#define ZELNODE_SYNC_FAILED 998
 #define ZELNODE_SYNC_FINISHED 999
 
 #define ZELNODE_SYNC_TIMEOUT 5
@@ -50,7 +50,7 @@ public:
     int RequestedZelnodeAttempt;
 
     // Time when current zelnode asset sync started
-    int64_t nAssetSyncStarted;
+    int64_t nTimeAssetSyncStarted;
 
     ZelnodeSync();
 
@@ -65,6 +65,8 @@ public:
     bool IsSynced();
     bool IsBlockchainSynced();
     bool IsZelnodeListSynced() { return RequestedZelnodeAssets > ZELNODE_SYNC_LIST; }
+    bool IsZelnodeWinnersSynced() { return RequestedZelnodeAssets > ZELNODE_SYNC_MNW; }
+    bool IsFailed() { return RequestedZelnodeAssets == ZELNODE_SYNC_FAILED; }
     void ClearFulfilledRequest();
 };
 


### PR DESCRIPTION
- Add checks to getblocktemplate - This should stop pools from sending miners data packets if they aren't synced with the zelnode data
- Remove spamming on logs