### PR TITLE
Update zelnode sync parameters

### DIFF
--- a/src/zelnode/zelnodesync.cpp
+++ b/src/zelnode/zelnodesync.cpp
@@ -105,24 +105,27 @@ void ZelnodeSync::GetNextAsset()
 {
     switch (RequestedZelnodeAssets) {
         case (ZELNODE_SYNC_FAILED): // should never be used here actually, use Reset() instead
-            ClearFulfilledRequest();
             RequestedZelnodeAssets = ZELNODE_SYNC_INITIAL;
             LogPrintf("ZelnodeSync::GetNextAsset -- Starting %s\n", GetSyncStatus());
             break;
         case(ZELNODE_SYNC_INITIAL):
+            ClearFulfilledRequest();
             RequestedZelnodeAssets = ZELNODE_SYNC_SPORKS;
             LogPrintf("ZelnodeSync::GetNextAsset -- Starting %s\n", GetSyncStatus());
             break;
         case (ZELNODE_SYNC_SPORKS):
             RequestedZelnodeAssets = ZELNODE_SYNC_LIST;
+            RequestedZelnodeAttempt = 0;
             LogPrintf("ZelnodeSync::GetNextAsset -- Starting %s\n", GetSyncStatus());
             break;
         case (ZELNODE_SYNC_LIST):
             RequestedZelnodeAssets = ZELNODE_SYNC_MNW;
+            RequestedZelnodeAttempt = 0;
             LogPrintf("ZelnodeSync::GetNextAsset -- Starting %s\n", GetSyncStatus());
             break;
         case (ZELNODE_SYNC_MNW):
             RequestedZelnodeAssets = ZELNODE_SYNC_FINISHED;
+            RequestedZelnodeAttempt = 0;
             LogPrintf("ZelnodeSync - Sync has finished\n");
             break;
     }
@@ -296,8 +299,7 @@ void ZelnodeSync::Process()
                 pnode->FulfilledRequest("znwsync");
 
                 // timeout
-                if (lastZelnodeWinner == 0 &&
-                    (RequestedZelnodeAttempt >= ZELNODE_SYNC_THRESHOLD * 3 || GetTime() - nTimeAssetSyncStarted > ZELNODE_SYNC_TIMEOUT * 10)) {
+                if (lastZelnodeWinner == 0 && (RequestedZelnodeAttempt >= ZELNODE_SYNC_THRESHOLD * 3 || GetTime() - nTimeAssetSyncStarted > ZELNODE_SYNC_TIMEOUT * 10)) {
                     if (IsSporkActive(SPORK_1_ZELNODE_PAYMENT_ENFORCEMENT)) {
                         LogPrintf("%s - ERROR - Syncing zelnode winners has failed, failed because %s, will try again\n", __func__, (RequestedZelnodeAttempt >= ZELNODE_SYNC_THRESHOLD * 3) ? "Requested zelnode attempt greater than threshold" : "nTimeAsset Sync timeout");
                         RequestedZelnodeAssets = ZELNODE_SYNC_FAILED;

--- a/src/zelnode/zelnodesync.h
+++ b/src/zelnode/zelnodesync.h
@@ -18,7 +18,7 @@
 #define ZELNODE_SYNC_FINISHED 999
 
 #define ZELNODE_SYNC_TIMEOUT 5
-#define ZELNODE_SYNC_THRESHOLD 2
+#define ZELNODE_SYNC_THRESHOLD 4 // Zelcash has a default 16 connections. So we want to communicate with at least 1/4 of them
 
 
 class ZelnodeSync;


### PR DESCRIPTION
- Some pools were having trouble getting out of sync with the zelnode data. This put them in a state were they weren't mining blocks as **getblocktemplate** was returning an error


These changes should allow for those nodes to get back in sync without having to interact with the node. The node should handle this automatically. 

If the node isn't able to get it back on track. The rpc command `znsync reset` can be used to force a resync of the zelnode data. 