### PR TITLE
listzelnodes - filter in pubkey

### DIFF
--- a/src/rpc/zelnode.cpp
+++ b/src/rpc/zelnode.cpp
@@ -408,7 +408,7 @@ UniValue listzelnodes(const UniValue& params, bool fHelp)
 
                     if (zn != NULL) {
                         if (strFilter != "" && strTxHash.find(strFilter) == string::npos &&
-                            zn->Status().find(strFilter) == string::npos &&
+                            zn->Status().find(strFilter) == string::npos && HexStr(zn->pubKeyZelnode).find(strFilter) &&
                             EncodeDestination(zn->pubKeyCollateralAddress.GetID()).find(strFilter) == string::npos) continue;
 
                         std::string strStatus = zn->Status();
@@ -448,7 +448,7 @@ UniValue listzelnodes(const UniValue& params, bool fHelp)
 
         if (zn != NULL) {
             if (strFilter != "" && strTxHash.find(strFilter) == string::npos &&
-                zn->Status().find(strFilter) == string::npos &&
+                zn->Status().find(strFilter) == string::npos && HexStr(zn->pubKeyZelnode).find(strFilter) &&
                     EncodeDestination(zn->pubKeyCollateralAddress.GetID()).find(strFilter) == string::npos) continue;
 
             std::string strStatus = zn->Status();
@@ -488,7 +488,7 @@ UniValue listzelnodes(const UniValue& params, bool fHelp)
 
         if (zn != NULL) {
             if (strFilter != "" && strTxHash.find(strFilter) == string::npos &&
-                zn->Status().find(strFilter) == string::npos &&
+                zn->Status().find(strFilter) == string::npos && HexStr(zn->pubKeyZelnode).find(strFilter) &&
                 EncodeDestination(zn->pubKeyCollateralAddress.GetID()).find(strFilter) == string::npos) continue;
 
             std::string strStatus = zn->Status();


### PR DESCRIPTION
Adds filtering through pubkey in listzelnodes command.

Backgorund:
ZelFlux receives messages from other nodes that are signed by the this zelnode keypair. Adding ability to filter listzelnodes via public key (that is part of the message) reduces computation in zelflux that does not have to do find operation to get the correct zelnode object.