### PR TITLE
Add zelnode params changes with fork height

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -86,7 +86,7 @@ public:
     CMainParams() {
         strNetworkID = "main";
         strCurrencyUnits = "ZEL";
-	bip44CoinType = 19167;
+	    bip44CoinType = 19167;
         consensus.fCoinbaseMustBeProtected = true;
         consensus.nSubsidySlowStartInterval = 5000;
         consensus.nSubsidyHalvingInterval = 655350; // 2.5 years
@@ -98,7 +98,7 @@ public:
         assert(maxUint/UintToArith256(consensus.powLimit) >= consensus.nDigishieldAveragingWindow);
         consensus.nDigishieldMaxAdjustDown = 32; // 32% adjustment down
         consensus.nDigishieldMaxAdjustUp = 16; // 16% adjustment up
-	consensus.nPowAllowMinDifficultyBlocksAfterHeight = boost::none;
+	    consensus.nPowAllowMinDifficultyBlocksAfterHeight = boost::none;
         consensus.nPowTargetSpacing = 2 * 60;
 
         consensus.vUpgrades[Consensus::BASE_SPROUT].nProtocolVersion = 170002;
@@ -109,31 +109,36 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_TESTDUMMY].nActivationHeight =
             Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
 
-	consensus.vUpgrades[Consensus::UPGRADE_LWMA].nProtocolVersion = 170002;
-	consensus.vUpgrades[Consensus::UPGRADE_LWMA].nActivationHeight = 125000;
+	    consensus.vUpgrades[Consensus::UPGRADE_LWMA].nProtocolVersion = 170002;
+	    consensus.vUpgrades[Consensus::UPGRADE_LWMA].nActivationHeight = 125000;
 
-	consensus.vUpgrades[Consensus::UPGRADE_EQUI144_5].nProtocolVersion = 170002;
-	consensus.vUpgrades[Consensus::UPGRADE_EQUI144_5].nActivationHeight = 125100;
+	    consensus.vUpgrades[Consensus::UPGRADE_EQUI144_5].nProtocolVersion = 170002;
+	    consensus.vUpgrades[Consensus::UPGRADE_EQUI144_5].nActivationHeight = 125100;
 
-	consensus.vUpgrades[Consensus::UPGRADE_ACADIA].nProtocolVersion = 170007;
+	    consensus.vUpgrades[Consensus::UPGRADE_ACADIA].nProtocolVersion = 170007;
         consensus.vUpgrades[Consensus::UPGRADE_ACADIA].nActivationHeight = 250000;		// Approx January 12th
         consensus.vUpgrades[Consensus::UPGRADE_ACADIA].hashActivationBlock =
                 uint256S("0000001d65fa78f2f6c172a51b5aca59ee1927e51f728647fca21b180becfe59");
 
-    consensus.vUpgrades[Consensus::UPGRADE_KAMIOOKA].nProtocolVersion = 170012;
+        consensus.vUpgrades[Consensus::UPGRADE_KAMIOOKA].nProtocolVersion = 170012;
         consensus.vUpgrades[Consensus::UPGRADE_KAMIOOKA].nActivationHeight = 372500;  // Approx July 2nd - Zel Team Boulder Meetup
         consensus.vUpgrades[Consensus::UPGRADE_KAMIOOKA].hashActivationBlock =
                 uint256S("00000052e2ac144c2872ff641c646e41dac166ac577bc9b0837f501aba19de4a");
 
         consensus.vUpgrades[Consensus::UPGRADE_KAMATA].nProtocolVersion = 170016;
         consensus.vUpgrades[Consensus::UPGRADE_KAMATA].nActivationHeight = 558000;  // 18th March
-        // TODO, add the activation block hash after activation
+        consensus.vUpgrades[Consensus::UPGRADE_KAMATA].hashActivationBlock =
+                uint256S("000000a33d38f37f586b843a9c8cf6d1ff1269e6114b34604cabcd14c44268d4");
+
+        consensus.vUpgrades[Consensus::UPGRADE_ZELNODE_PARAMS].nProtocolVersion = 170017;
+        consensus.vUpgrades[Consensus::UPGRADE_ZELNODE_PARAMS].nActivationHeight = 999999; // TODO set height
+        // TODO add block hash after the fork happens
 
 
         consensus.nZawyLWMAAveragingWindow = 60;
-	consensus.eh_epoch_fade_length = 11;
+	    consensus.eh_epoch_fade_length = 11;
 
-	eh_epoch_1 = eh200_9;
+	    eh_epoch_1 = eh200_9;
         eh_epoch_2 = eh144_5;
         eh_epoch_3 = zelHash;
 
@@ -206,7 +211,11 @@ public:
 
         nStartZelnodePaymentsHeight = 560000; // Start paying deterministic zelnodes on height
 
-        strBenchmarkingPublicKey = "042e79d7dd1483996157df6b16c831be2b14b31c69944ea2a585c63b5101af1f9517ba392cee5b1f45a62e9d936488429374535a2f76870bfa8eea6667b13eb39e";
+        // These are the benchmarking public keys, if you are adding a key, you must increase the resize integer
+        vecBenchmarkingPublicKeys.resize(1);
+        vecBenchmarkingPublicKeys[0] = std::make_pair("042e79d7dd1483996157df6b16c831be2b14b31c69944ea2a585c63b5101af1f9517ba392cee5b1f45a62e9d936488429374535a2f76870bfa8eea6667b13eb39e", 0);
+        assert(vecBenchmarkingPublicKeys.size() > 0);
+
 
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of
@@ -280,6 +289,9 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_KAMATA].nProtocolVersion = 170016;
         consensus.vUpgrades[Consensus::UPGRADE_KAMATA].nActivationHeight = 350;
 
+        consensus.vUpgrades[Consensus::UPGRADE_ZELNODE_PARAMS].nProtocolVersion = 170017;
+        consensus.vUpgrades[Consensus::UPGRADE_ZELNODE_PARAMS].nActivationHeight = 999999;  // 18th March // TODO set height
+
 
         consensus.nZawyLWMAAveragingWindow = 60;
 	    consensus.eh_epoch_fade_length = 10;
@@ -348,8 +360,12 @@ public:
         strSporkKey = "0408c6a3a6cacb673fc38f27c75d79c865e1550441ea8b5295abf21116972379a1b49416da07b7d9b40fb9daf8124f309c608dfc79756a5d3c2a957435642f7f1a";
         networkID = CBaseChainParams::Network::TESTNET;
         strZelnodeTestingDummyAddress= "tmXxZqbmvrxeSFQsXmm4N9CKyME767r47fS";
-        strBenchmarkingPublicKey = "04d422e01f5acff68504b92df96a9004cf61be432a20efe83fe8a94c1aa730fe7dece5d2e8298f2d5672d4e569c55d9f0a73268ef7b92990d8c014e828a7cc48dd";
+
         nStartZelnodePaymentsHeight = 350;
+
+        vecBenchmarkingPublicKeys.resize(1);
+        vecBenchmarkingPublicKeys[0] = std::make_pair("04d422e01f5acff68504b92df96a9004cf61be432a20efe83fe8a94c1aa730fe7dece5d2e8298f2d5672d4e569c55d9f0a73268ef7b92990d8c014e828a7cc48dd", 0);
+        assert(vecBenchmarkingPublicKeys.size() > 0);
 
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of
@@ -424,6 +440,10 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_KAMATA].nActivationHeight =
                 Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
 
+        consensus.vUpgrades[Consensus::UPGRADE_ZELNODE_PARAMS].nProtocolVersion = 170017;
+        consensus.vUpgrades[Consensus::UPGRADE_ZELNODE_PARAMS].nActivationHeight =
+                Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
+
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00");
@@ -462,7 +482,9 @@ public:
         fTestnetToBeDeprecatedFieldRPC = false;
 
         networkID = CBaseChainParams::Network::REGTEST;
-        strBenchmarkingPublicKey = "04cf3c34f01486bbb34c1a7ca11c2ddb1b3d98698c3f37d54452ff91a8cd5e92a6910ce5fc2cc7ad63547454a965df53ff5be740d4ef4ac89848c2bafd1e40e6b7";
+        vecBenchmarkingPublicKeys.resize(1);
+        vecBenchmarkingPublicKeys[0] = std::make_pair("04cf3c34f01486bbb34c1a7ca11c2ddb1b3d98698c3f37d54452ff91a8cd5e92a6910ce5fc2cc7ad63547454a965df53ff5be740d4ef4ac89848c2bafd1e40e6b7", 0);
+        assert(vecBenchmarkingPublicKeys.size() > 0);
 
         checkpointData = (CCheckpointData){
             boost::assign::map_list_of

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -130,7 +130,7 @@ public:
     std::string ZelnodeTestingDummyAddress() const { return strZelnodeTestingDummyAddress; }
     int64_t StartZelnodePayments() const { return nStartZelnodePaymentsHeight; }
     CBaseChainParams::Network NetworkID() const { return networkID; }
-    std::string BenchmarkingPublicKey() const { return strBenchmarkingPublicKey; }
+    std::vector<std::pair<std::string, uint32_t> > BenchmarkingPublicKeys() const { return vecBenchmarkingPublicKeys; }
 
 
 protected:
@@ -174,6 +174,7 @@ protected:
     int64_t nStartZelnodePaymentsHeight;
     CBaseChainParams::Network networkID;
     std::string strBenchmarkingPublicKey;
+    std::vector< std::pair<std::string, uint32_t> > vecBenchmarkingPublicKeys;
 };
 
 /**

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -30,6 +30,7 @@ enum UpgradeIndex {
     UPGRADE_ACADIA,
     UPGRADE_KAMIOOKA,
     UPGRADE_KAMATA,
+    UPGRADE_ZELNODE_PARAMS,
     // NOTE: Also add new upgrades to NetworkUpgradeInfo in upgrades.cpp
     MAX_NETWORK_UPGRADES
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3703,6 +3703,10 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
             return AbortNode(state, "Failed to read block");
         pblock = &block;
     }
+
+    // Set the starting lastManaged height for zelnodes
+    static int nZelnodeLastManaged = pindexNew->nHeight;
+
     // Get the current commitment tree
     SproutMerkleTree oldSproutTree;
     SaplingMerkleTree oldSaplingTree;
@@ -3775,7 +3779,9 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
 
     EnforceNodeDeprecation(pindexNew->nHeight);
 
-    if (fZelnode && pindexNew->nHeight % 2) {
+    // Every 3 blocks check to see if the zelnode should do anything
+    if (fZelnode && pindexNew->nHeight - nZelnodeLastManaged >= 3) {
+        nZelnodeLastManaged = pindexNew->nHeight;
         activeZelnode.ManageDeterministricZelnode();
     }
 

--- a/src/zelnode/activezelnode.cpp
+++ b/src/zelnode/activezelnode.cpp
@@ -172,7 +172,7 @@ void ActiveZelnode::ManageDeterministricZelnode()
         if (mempool.mapZelnodeTxMempool.count(activeZelnode.deterministicOutPoint)) {
             if (pwalletMain)
                 pwalletMain->ResendWalletTransactions(GetAdjustedTime());
-            LogPrintf("Zelnode found in start tracker. Skipping confirm transaction creation, because tranasaction already in mempool %s\n", activeZelnode.deterministicOutPoint.ToString());
+            LogPrintf("Zelnode found in start tracker. Skipping confirm transaction creation, because transaction already in mempool %s\n", activeZelnode.deterministicOutPoint.ToString());
             return;
         }
 

--- a/src/zelnode/zelnode.cpp
+++ b/src/zelnode/zelnode.cpp
@@ -854,7 +854,7 @@ std::string TierToString(int tier)
     return strStatus;
 }
 
-bool CheckZelnodeTxSignatures(const CTransaction& transaction)
+bool CheckZelnodeTxSignatures(const CTransaction&  transaction)
 {
     if (transaction.nType & ZELNODE_START_TX_TYPE) {
         // We need to sign the mutable transaction
@@ -894,7 +894,7 @@ bool CheckZelnodeTxSignatures(const CTransaction& transaction)
 
 bool CheckBenchmarkSignature(const CTransaction& transaction)
 {
-    std::string public_key = Params().BenchmarkingPublicKey();
+    std::string public_key = GetZelnodeBenchmarkPublicKey(transaction);
     CPubKey pubkey(ParseHex(public_key));
     std::string errorMessage = "";
     std::string strMessage = std::string(transaction.sig.begin(), transaction.sig.end()) + std::to_string(transaction.benchmarkTier) + std::to_string(transaction.benchmarkSigTime) + transaction.ip;
@@ -921,7 +921,8 @@ void GetUndoDataForExpiredZelnodeDosScores(CZelnodeTxBlockUndo& p_zelnodeTxUndoD
 void GetUndoDataForExpiredConfirmZelnodes(CZelnodeTxBlockUndo& p_zelnodeTxUndoData, const int& p_nHeight, const std::set<COutPoint> setSpentOuts)
 {
     LOCK(g_zelnodeCache.cs);
-    int nHeightToExpire = p_nHeight - ZELNODE_CONFIRM_UPDATE_EXPIRATION_HEIGHT;
+    int nExpirationCount = GetZelnodeExpirationCount(p_nHeight);
+    int nHeightToExpire = p_nHeight - nExpirationCount;
 
     for (const auto& item : g_zelnodeCache.mapConfirmedZelnodeData) {
         // The p_zelnodeTxUndoData has a map of all new confirms that have been updated this block. So if it is in there don't expire it. They made it barely in time
@@ -1917,4 +1918,40 @@ void ZelnodeCache::CountNetworks(int& ipv4, int& ipv6, int& onion) {
                 break;
         }
     }
+}
+
+int GetZelnodeExpirationCount(const int& p_nHeight)
+{
+    // Get the status on if Zelnode params1 is activated
+    bool fZelnodeParams1Active = NetworkUpgradeActive(p_nHeight, Params().GetConsensus(), Consensus::UPGRADE_ZELNODE_PARAMS);
+
+    if (fZelnodeParams1Active) {
+        return ZELNODE_CONFIRM_UPDATE_EXPIRATION_HEIGHT_PARAMS_1;
+    } else {
+        return ZELNODE_CONFIRM_UPDATE_EXPIRATION_HEIGHT;
+    }
+}
+
+std::string GetZelnodeBenchmarkPublicKey(const CTransaction& tx)
+{
+    // Get the public keys and timestamps from the chainparams
+    std::vector< std::pair<std::string, uint32_t> > vectorPublicKeys = Params().BenchmarkingPublicKeys();
+
+    // If only have one public key return it
+    if (vectorPublicKeys.size() == 1) {
+        return vectorPublicKeys[0].first;
+    }
+
+    // Get the last index in the array
+    int nLast = vectorPublicKeys.size() - 1;
+
+    // Loop backwards until we find the correct public key
+    for (int i = nLast; i >= 0; i--) {
+        if (tx.benchmarkSigTime >= vectorPublicKeys[i].second) {
+            return vectorPublicKeys[i].first;
+        }
+    }
+
+    // Only reason this should happen is if there is a problem with the chainparams
+    return vectorPublicKeys[0].first;
 }

--- a/src/zelnode/zelnode.h
+++ b/src/zelnode/zelnode.h
@@ -41,6 +41,7 @@
 
 // How often a new confirmation transaction needs to be seen on chain to keep a node up and running
 #define ZELNODE_CONFIRM_UPDATE_EXPIRATION_HEIGHT 60
+#define ZELNODE_CONFIRM_UPDATE_EXPIRATION_HEIGHT_PARAMS_1 80
 
 // Nodes are allowed to send a update confirm notification only after this many blocks past there last confirm
 #define ZELNODE_CONFIRM_UPDATE_MIN_HEIGHT 40
@@ -721,6 +722,9 @@ public:
 
     void CountNetworks(int& ipv4, int& ipv6, int& onion);
 };
+
+int GetZelnodeExpirationCount(const int& p_nHeight);
+std::string GetZelnodeBenchmarkPublicKey(const CTransaction& tx);
 
 bool IsDZelnodeActive();
 bool IsZelnodeTransactionsActive();


### PR DESCRIPTION
- Add ability to easily change the benchmark public key into the chainparams with a timestamp ( must make similar changes to zelbench
- Added forking changes that push the zelnode confirmation expiration to 80 blocks (from 60)
- Reformatted chainparams so the lines lineup