### PR TITLE
Add missing lastIpAddress logic into undoblock

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,6 +116,7 @@ CScript COINBASE_FLAGS;
 
 const string strMessageMagic = "Zelcash Signed Message:\n";
 
+
 // Internal stuff
 namespace {
 
@@ -3358,11 +3359,16 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                     } else if (tx.nUpdateType == ZelnodeUpdateType::UPDATE_CONFIRM) {
                         if (p_zelnodeCache) {
                             p_zelnodeCache->AddUpdateConfirm(tx, pindex->nHeight);
-                            auto global_data = g_zelnodeCache.GetZelnodeData(tx.collateralOut);
-                            if (global_data.IsNull())
-                                return state.DoS(100, error("ConnectBlock(): zelnode tx, failed finding data to creating undo data"),
+                            ZelnodeCacheData global_data = g_zelnodeCache.GetZelnodeData(tx.collateralOut);
+                            if (global_data.IsNull()) {
+                                return state.DoS(100,
+                                                 error("ConnectBlock(): zelnode tx, failed finding data to creating undo data"),
                                                  REJECT_INVALID, "bad-txns-zelnode-global-data-not-found");
+                            }
+
+                            // Add the lastConfirmed and lastIpAddress into the undoblock data
                             zelnodeTxBlockUndo.mapUpdateLastConfirmHeight.insert(std::make_pair(tx.collateralOut, global_data.nLastConfirmedBlockHeight));
+                            zelnodeTxBlockUndo.mapLastIpAddress.insert(std::make_pair(tx.collateralOut, global_data.ip));
                         }
                     }
                 }

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -231,7 +231,7 @@ bool CheckEquihashSolution(const CBlockHeader *pblock, const Consensus::Params& 
         default: return error("CheckEquihashSolution: Unsupported solution size of %d", nSolSize);
     }
 
-    LogPrint("pow", "selected n,k : %d, %d \n", n,k);
+//    LogPrint("pow", "selected n,k : %d, %d \n", n,k);
 
     //need to put block height param switching code here
 

--- a/src/undo.h
+++ b/src/undo.h
@@ -79,6 +79,21 @@ public:
     }
 };
 
+template <typename Stream, typename Operation>
+void ReadWriteExtraZelnodeUndoBlockData(Stream &s, Operation ser_action, std::map<COutPoint, std::string> &mapLastIpAddress)
+{
+    if (ser_action.ForRead())
+    {
+        if (!s.empty()) {
+            READWRITE(mapLastIpAddress);
+        }
+    }
+    else
+    {
+        READWRITE(mapLastIpAddress);
+    }
+};
+
 class CZelnodeTxBlockUndo
 {
 public:
@@ -86,6 +101,7 @@ public:
     std::vector<ZelnodeCacheData> vecExpiredConfirmedData;
     std::map<COutPoint, int> mapUpdateLastConfirmHeight;
     std::map<COutPoint, int> mapLastPaidHeights;
+    std::map<COutPoint, std::string> mapLastIpAddress;
 
     ADD_SERIALIZE_METHODS;
 
@@ -95,6 +111,7 @@ public:
         READWRITE(vecExpiredConfirmedData);
         READWRITE(mapUpdateLastConfirmHeight);
         READWRITE(mapLastPaidHeights);
+        ReadWriteExtraZelnodeUndoBlockData(s, ser_action, mapLastIpAddress);
     }
 };
 


### PR DESCRIPTION
Nodes were stuck on the network:

- Added it into the undoblock database, and made sure that if a block is undone, that the old ipAddress is restored


What I think happened: 

- A flux node was confirmed on the network with Ip Address: **A**
- 5 blocks later it sent a new confirmation tx to the network in which an ip address change was made to Ip Address: **B**
- The tx was mined into a block, and broadcasted out as block: **1**
- Another block was also mined that orphaned block **1**, and replaced it: calling it block **2** 
- Because this lastIpAddress logic wasn't in place, when block **1** was orphaned its ip address stayed as **B**, instead of reverting back to **A**.

