### PR TITLE
Remove unneeded logic from IsInitialBlockDownload causing crashes

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -132,7 +132,7 @@ public:
 
         consensus.vUpgrades[Consensus::UPGRADE_FLUX].nProtocolVersion = 170017;
         consensus.vUpgrades[Consensus::UPGRADE_FLUX].nActivationHeight = 835554;  // Around 10th April 2021
-        consensus.vUpgrades[Consensus::UPGRADE_KAMATA].hashActivationBlock =
+        consensus.vUpgrades[Consensus::UPGRADE_FLUX].hashActivationBlock =
                 uint256S("000000ce99aa6765bdaae673cdf41f661ff20a116eb6f2fe0843488d8061f193");
 
         consensus.nZawyLWMAAveragingWindow = 60;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -132,6 +132,8 @@ public:
 
         consensus.vUpgrades[Consensus::UPGRADE_FLUX].nProtocolVersion = 170017;
         consensus.vUpgrades[Consensus::UPGRADE_FLUX].nActivationHeight = 835554;  // Around 10th April 2021
+        consensus.vUpgrades[Consensus::UPGRADE_KAMATA].hashActivationBlock =
+                uint256S("000000ce99aa6765bdaae673cdf41f661ff20a116eb6f2fe0843488d8061f193");
 
         consensus.nZawyLWMAAveragingWindow = 60;
 	    consensus.eh_epoch_fade_length = 11;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2141,7 +2141,7 @@ bool GetSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value)
         return true;
 
     if (!pblocktree->ReadSpentIndex(key, value))
-        return error("Unable to get spent index information");
+        return false;
 
     return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2423,29 +2423,7 @@ bool IsInitialBlockDownload(const CChainParams& chainParams)
         return true;
     if (chainActive.Tip()->nChainWork < UintToArith256(chainParams.GetConsensus().nMinimumChainWork))
         return true;
-    // Don't bother checking Sprout, it is always active.
-    for (int idx = Consensus::BASE_SPROUT + 1; idx < Consensus::MAX_NETWORK_UPGRADES; idx++) {
-        // If we expect a particular activation block hash, and either the upgrade is not
-        // active or it doesn't match the block at that height on the current chain, then
-        // we are not on the correct chain. As we have already checked that the current
-        // chain satisfies the minimum chain work, this is likely an adversarial situation
-        // where the node is being fed a fake alternate chain; shut down for safety.
-        auto upgrade = chainParams.GetConsensus().vUpgrades[idx];
-        if (upgrade.hashActivationBlock && (
-            !NetworkUpgradeActive(chainActive.Height(), chainParams.GetConsensus(), Consensus::UpgradeIndex(idx))
-            || chainActive[upgrade.nActivationHeight]->GetBlockHash() != upgrade.hashActivationBlock.get()
-        )) {
-            AbortNode(
-                strprintf(
-                    "%s: Activation block hash mismatch for the %s network upgrade (expected %s, found %s). Likely adversarial condition; shutting down for safety.",
-                    __func__,
-                    NetworkUpgradeInfo[idx].strName,
-                    upgrade.hashActivationBlock.get().GetHex(),
-                    chainActive[upgrade.nActivationHeight]->GetBlockHash().GetHex()),
-                _("We are on a chain with sufficient work, but the network upgrade checkpoints do not match. Your node may be under attack! Shutting down for safety."));
-            return true;
-        }
-    }
+
     if (chainActive.Tip()->GetBlockTime() < (GetTime() - nMaxTipAge))
         return true;
     LogPrintf("Leaving InitialBlockDownload (latching to false)\n");

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -151,7 +151,7 @@ UniValue blockToDeltasJSON(const CBlock& block, const CBlockIndex* blockindex)
         entry.push_back(Pair("index", (int)i));
 
         UniValue inputs(UniValue::VARR);
-        if (!tx.IsCoinBase() && !tx.IsZelnodeTx()) {
+        if (!tx.IsCoinBase()) {
             for (size_t j = 0; j < tx.vin.size(); j++) {
                 const CTxIn input = tx.vin[j];
                 UniValue delta(UniValue::VOBJ);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -151,7 +151,7 @@ UniValue blockToDeltasJSON(const CBlock& block, const CBlockIndex* blockindex)
         entry.push_back(Pair("index", (int)i));
 
         UniValue inputs(UniValue::VARR);
-        if (!tx.IsCoinBase()) {
+        if (!tx.IsCoinBase() && !tx.IsZelnodeTx()) {
             for (size_t j = 0; j < tx.vin.size(); j++) {
                 const CTxIn input = tx.vin[j];
                 UniValue delta(UniValue::VOBJ);

--- a/src/rpc/zelnode.cpp
+++ b/src/rpc/zelnode.cpp
@@ -629,6 +629,10 @@ UniValue viewdeterministiczelnodelist(const UniValue& params, bool fHelp)
                 "\nExamples:\n" +
                 HelpExampleCli("viewdeterministiczelnodelist", ""));
 
+    if (IsInitialBlockDownload(Params())) {
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Wait until chain is synced closer to tip");
+    }
+
     std::string strFilter = "";
 
     if (params.size() == 1) strFilter = params[0].get_str();


### PR DESCRIPTION
45202f784cb6f733de0e31614f232040ffc725fb -> This logic was inherited from zcash, and I do not think it is needed anylonger. It is causing crashes on machines that are syncing from scratch because it tries to check an OutOfBounds height in the chainActive array. 

5235d832a483f5b35a54117ae4b9bf02a4bbe304 -> Nodes were crashing during sync, this was one of the backtraces. Hoping that this commit fixes the problem that were occuring. 

`(gdb) backtrace
#0  __memcmp_sse4_1 () at ../sysdeps/x86_64/multiarch/memcmp-sse4.S:1529
#1  0x0000555555810cd3 in operator< (b=..., a=...) at ./uint256.h:93
#2  operator< (b=..., a=...) at ./primitives/transaction.h:342
#3  std::less<COutPoint>::operator() (__y=..., __x=..., this=0x5555564bd150 <g_zelnodeCache+592>) at /usr/include/c++/7/bits/stl_function.h:386
#4  std::_Rb_tree<COutPoint, std::pair<COutPoint const, ZelnodeCacheData>, std::_Select1st<std::pair<COutPoint const, ZelnodeCacheData> >, std::less<COutPoint>, std::allocator<std::pair<COutPoint const, ZelnodeCacheData> > >::_M_lower_bound (__k=..., __y=0x5555564bd158 <g_zelnodeCache+600>, __x=0x55557a2dc760, this=0x5555564bd150 <g_zelnodeCache+592>)
    at /usr/include/c++/7/bits/stl_tree.h:1888
#5  std::_Rb_tree<COutPoint, std::pair<COutPoint const, ZelnodeCacheData>, std::_Select1st<std::pair<COutPoint const, ZelnodeCacheData> >, std::less<COutPoint>, std::allocator<std::pair<COutPoint const, ZelnodeCacheData> > >::find (this=this@entry=0x5555564bd150 <g_zelnodeCache+592>, __k=...) at /usr/include/c++/7/bits/stl_tree.h:2536
#6  0x00005555558032b0 in std::map<COutPoint, ZelnodeCacheData, std::less<COutPoint>, std::allocator<std::pair<COutPoint const, ZelnodeCacheData> > >::count (__x=...,
    this=0x5555564bd150 <g_zelnodeCache+592>) at /usr/include/c++/7/bits/stl_map.h:1209
#7  ZelnodeCache::GetZelnodeData (this=0x5555564bcf00 <g_zelnodeCache>, out=..., nNeedLocation=nNeedLocation@entry=0x0) at zelnode/zelnode.cpp:1168
#8  0x00005555557718c6 in viewdeterministiczelnodelist (params=..., fHelp=false) at rpc/zelnode.cpp:640
#9  0x000055555575a819 in CRPCTable::execute (this=<optimized out>, strMethod="viewdeterministiczelnodelist", params=...) at rpc/server.cpp:452
#10 0x000055555584399c in HTTPReq_JSONRPC (req=0x7fffd0003830) at httprpc.cpp:130
#11 0x00005555556f2b7b in boost::detail::function::void_function_invoker2<bool (*)(HTTPRequest*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&), void, HTTPRequest*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>::invoke (function_ptr=..., a0=<optimized out>, a1=...)
    at /mnt/nvme/zelcash/depends/x86_64-unknown-linux-gnu/share/../include/boost/function/function_template.hpp:117
#12 0x0000555555849881 in boost::function2<void, HTTPRequest*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>::operator() (a1=...,
    a0=<optimized out>, this=<optimized out>) at /mnt/nvme/zelcash/depends/x86_64-unknown-linux-gnu/share/../include/boost/function/function_template.hpp:763
#13 HTTPWorkItem::operator() (this=<optimized out>) at httpserver.cpp:51
#14 0x0000555555847454 in WorkQueue<HTTPClosure>::Run (this=0x555556a9d1e0) at httpserver.cpp:137
#15 HTTPWorkQueueRun (queue=0x555556a9d1e0) at httpserver.cpp:359
#16 0x0000555555849312 in boost::_bi::list1<boost::_bi::value<WorkQueue<HTTPClosure>*> >::operator()<void (*)(WorkQueue<HTTPClosure>*), boost::_bi::list0> (
    a=<synthetic pointer>..., f=<optimized out>, this=<optimized out>) at /mnt/nvme/zelcash/depends/x86_64-unknown-linux-gnu/share/../include/boost/bind/bind.hpp:259
#17 boost::_bi::bind_t<void, void (*)(WorkQueue<HTTPClosure>*), boost::_bi::list1<boost::_bi::value<WorkQueue<HTTPClosure>*> > >::operator() (this=<optimized out>)
    at /mnt/nvme/zelcash/depends/x86_64-unknown-linux-gnu/share/../include/boost/bind/bind.hpp:1294
#18 boost::detail::thread_data<boost::_bi::bind_t<void, void (*)(WorkQueue<HTTPClosure>*), boost::_bi::list1<boost::_bi::value<WorkQueue<HTTPClosure>*> > > >::run (
    this=<optimized out>) at /mnt/nvme/zelcash/depends/x86_64-unknown-linux-gnu/share/../include/boost/thread/detail/thread.hpp:120
#19 0x0000555555ac0d3a in thread_proxy ()
#20 0x00007ffff78326db in start_thread (arg=0x7fffe1e35700) at pthread_create.c:463
#21 0x00007ffff699571f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95`