### PR TITLE
Add fluxnodecount index flag

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -241,6 +241,10 @@ public:
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     uint32_t nSequenceId;
 
+    int nStratus = 0;
+    int nNimbus = 0;
+    int nCumulus = 0;
+
     void SetNull()
     {
         phashBlock = NULL;
@@ -270,6 +274,10 @@ public:
         nBits          = 0;
         nNonce         = uint256();
         nSolution.clear();
+
+        nStratus = 0;
+        nNimbus = 0;
+        nCumulus = 0;
     }
 
     CBlockIndex()
@@ -454,6 +462,10 @@ public:
         if ((s.GetType() & SER_DISK) && (nVersion >= SAPLING_VALUE_VERSION)) {
             READWRITE(nSaplingValue);
         }
+
+        READWRITE(nStratus);
+        READWRITE(nNimbus);
+        READWRITE(nCumulus);
 
         // If you have just added new serialized fields above, remember to add
         // them to CBlockTreeDB::LoadBlockIndexGuts() in txdb.cpp :)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -263,7 +263,6 @@ public:
         strFoundationFundingAddress = "t3XjYMBvwxnXVv9jqg4CgokZ3f7kAoXPQL8";
         nFoundationFundingHeight = 836994;  // Around 11th April 2021
         nFoundationFundingAmount = 2500000 * COIN; // 2.5 Million
-
         strSwapPoolAddress = "t3ThbWogDoAjGuS6DEnmN1GWJBRbVjSUK4T";
         nSwapPoolStartHeight = 837714; //  // Around 12th April 2021
         nSwapPoolAmount = 22000000 * COIN; // 22 Million every time

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1564,6 +1564,12 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
                     break;
                 }
 
+                // Check for changed -fluxnodecount state
+                if (fFluxNodeCountIndex != GetBoolArg("-fluxnodecount", false)) {
+                    strLoadError = _("You need to rebuild the database using -reindex to change -fluxnodecount");
+                    break;
+                }
+
                 // Check for changed -insightexplorer state
                 if (fInsightExplorer != GetBoolArg("-insightexplorer", false)) {
                     strLoadError = _("You need to rebuild the database using -reindex to change -insightexplorer");

--- a/src/main.h
+++ b/src/main.h
@@ -154,6 +154,7 @@ extern bool fImporting;
 extern bool fReindex;
 extern int nScriptCheckThreads;
 extern bool fTxIndex;
+extern bool fFluxNodeCountIndex;
 
 extern bool fIsVerifying;
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -147,7 +147,9 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "z_setmigration", 0},
     { "spork", 1},
     { "printsnapshot", 0},
-    { "createp2shstarttx", 3}
+    { "createp2shstarttx", 3},
+    { "getfluxnodecount", 0},
+    { "getfluxnodecount", 1}
 };
 
 class CRPCConvertTable

--- a/src/rpc/fluxnode.cpp
+++ b/src/rpc/fluxnode.cpp
@@ -1137,7 +1137,10 @@ UniValue getfluxnodecount (const UniValue& params, bool fHelp, string cmdname)
         throw runtime_error(
                 cmdname + "\n"
                 "\nGet fluxnode count values\n"
-                ""
+
+                  "\nArguments:\n"
+                  "1. history         (boolean, optional) Specifiy if you want all fluxnode counts from all blocks (-fluxnodecount=1 required)\n"
+                  "2. timetable       (number, optional) Default=360 How often you want the fluxnode count. 360 = 12 Hours, 720 = 1 Day. Range is (1, 99999999)\n"
 
                 "\nResult:\n"
                 "{\n"
@@ -1159,10 +1162,18 @@ UniValue getfluxnodecount (const UniValue& params, bool fHelp, string cmdname)
        fAll = params[0].get_bool();
     }
 
-    // Get Global Data
+    if (fAll && !fFluxNodeCountIndex) {
+        throw JSONRPCError(RPC_INVALID_REQUEST, "history was requested but fluxnodecount is not enabled. You must have fluxnodecount=1 in flux.conf");
+    }
+
+    // Get Global Data instead of current blocks count
     if (fAll) {
         if (params.size() == 2) {
             nSpread = params[1].get_int();
+        }
+
+        if (nSpread <= 0 || nSpread >= 100000000) {
+            nSpread = 360;
         }
 
         LOCK(cs_main);

--- a/src/rpc/fluxnode.cpp
+++ b/src/rpc/fluxnode.cpp
@@ -1157,7 +1157,7 @@ UniValue getfluxnodecount (const UniValue& params, bool fHelp, string cmdname)
 
     // Global Numbers
     bool fAll = false;
-    uint16_t nSpread = 360; // 360 = 12 hours with 2 minute blocks. 720 blocks a day
+    uint32_t nSpread = 360; // 360 = 12 hours with 2 minute blocks. 720 blocks a day
     if (params.size() >= 1) {
        fAll = params[0].get_bool();
     }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1139,7 +1139,7 @@ UniValue sendrawtransaction(const UniValue& params, bool fHelp)
 
     bool fOverrideFees = false;
     if (params.size() > 1)
-        fOverrideFees = true;
+        fOverrideFees = params[1].get_bool();
 
     CCoinsViewCache &view = *pcoinsTip;
     const CCoins* existingCoins = view.AccessCoins(hashTx);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1139,7 +1139,7 @@ UniValue sendrawtransaction(const UniValue& params, bool fHelp)
 
     bool fOverrideFees = false;
     if (params.size() > 1)
-        fOverrideFees = params[1].get_bool();
+        fOverrideFees = true;
 
     CCoinsViewCache &view = *pcoinsTip;
     const CCoins* existingCoins = view.AccessCoins(hashTx);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -527,6 +527,10 @@ bool CBlockTreeDB::LoadBlockIndexGuts(boost::function<CBlockIndex*(const uint256
                 pindexNew->nSproutValue   = diskindex.nSproutValue;
                 pindexNew->nSaplingValue  = diskindex.nSaplingValue;
 
+                pindexNew->nStratus = diskindex.nStratus;
+                pindexNew->nNimbus = diskindex.nNimbus;
+                pindexNew->nCumulus = diskindex.nCumulus;
+
                 // Consistency checks
                 auto header = pindexNew->GetBlockHeader();
                 if (header.GetHash() != pindexNew->GetBlockHash())


### PR DESCRIPTION
This PR adds a new index flag **fluxnodecount**. 

This flag will require a reindex to take place as it modifies the CBlockIndex to include the number of confirmed nodes in each tier at each block height. 

If this is enabled, you can call getfluxnodecount with additional paramters. 
History starts at block **558000** - When deterministic fluxnodes went live

I suggest putting the output to a file ">> history.json" as the data size is pretty large when using smaller numbers

**getfluxnodecount true >> history.json** - this will return all fluxnode counts from start every 360 blocks or ~12 hours. 
**getfluxnodecount true 720 >> history.json** - this will return all fluxnode counts from start every 720 blocks or ~1 day. 
**getfluxnodecount true 1 >> history.json** - this will return all fluxnode counts from start every block. 

For example 

**getfluxnodecount true 250000** returns

```json{
  "558000": {
    "stratus": 0,
    "nimbus": 0,
    "cumulus": 0
  },
  "808000": {
    "stratus": 218,
    "nimbus": 297,
    "cumulus": 180
  },
  "1058000": {
    "stratus": 543,
    "nimbus": 877,
    "cumulus": 1244
  },
  "1308000": {
    "stratus": 2112,
    "nimbus": 2435,
    "cumulus": 10898
  },
  "1558000": {
    "stratus": 1770,
    "nimbus": 2005,
    "cumulus": 8359
  }
}`

