### PR TITLE
Fluxnode undo data not written on block reconnection during PON reorgs

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3890,34 +3890,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             pindex->nStatus |= BLOCK_HAVE_UNDO;
         }
 
-        if (fluxnodeTxBlockUndo.vecExpiredDosData.size() ||
-            fluxnodeTxBlockUndo.vecExpiredConfirmedData.size() ||
-            fluxnodeTxBlockUndo.mapUpdateLastConfirmHeight.size() ||
-            fluxnodeTxBlockUndo.mapLastPaidHeights.size())
-        {
-            if (!pFluxnodeDB->WriteBlockUndoFluxnodeData(block.GetHash(), fluxnodeTxBlockUndo))
-                return AbortNode(state, "Failed to write fluxnodetx undo data");
-        }
-
-        // Add delegate updates to the cache instead of writing directly to database
-        for (const auto& item : mapNewDelegates) {
-            if (item.second.delegateStartingKeys.empty()) {
-                // If no keys, mark for erasure
-                if (p_fluxnodeCache) {
-                    p_fluxnodeCache->setDelegateToErase.insert(item.first);
-                    // Remove from write map if it was there
-                    p_fluxnodeCache->mapDelegateToWrite.erase(item.first);
-                }
-            } else {
-                // Add to write map
-                if (p_fluxnodeCache) {
-                    p_fluxnodeCache->mapDelegateToWrite[item.first] = item.second;
-                    // Remove from erase set if it was there
-                    p_fluxnodeCache->setDelegateToErase.erase(item.first);
-                }
-            }
-        }
-
         // Now that all consensus rules have been validated, set nCachedBranchId.
         // Move this if BLOCK_VALID_CONSENSUS is ever altered.
         static_assert(BLOCK_VALID_CONSENSUS == BLOCK_VALID_SCRIPTS,
@@ -3931,6 +3903,39 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
         pindex->RaiseValidity(BLOCK_VALID_SCRIPTS);
         setDirtyBlockIndex.insert(pindex);
+    }
+
+    // Always write fluxnode undo data, even for reconnected blocks.
+    // The undo data depends on the current chain state at connection time, which may differ
+    // from when the block was first connected (due to PON competing blocks and reorgs).
+    // Since this is keyed by block hash in LevelDB, overwriting is safe.
+    if (fluxnodeTxBlockUndo.vecExpiredDosData.size() ||
+        fluxnodeTxBlockUndo.vecExpiredConfirmedData.size() ||
+        fluxnodeTxBlockUndo.mapUpdateLastConfirmHeight.size() ||
+        fluxnodeTxBlockUndo.mapLastPaidHeights.size())
+    {
+        if (!pFluxnodeDB->WriteBlockUndoFluxnodeData(block.GetHash(), fluxnodeTxBlockUndo))
+            return AbortNode(state, "Failed to write fluxnodetx undo data");
+    }
+
+    // Always process delegate updates, even for reconnected blocks.
+    // Like fluxnode undo data, delegate state depends on current chain state.
+    for (const auto& item : mapNewDelegates) {
+        if (item.second.delegateStartingKeys.empty()) {
+            // If no keys, mark for erasure
+            if (p_fluxnodeCache) {
+                p_fluxnodeCache->setDelegateToErase.insert(item.first);
+                // Remove from write map if it was there
+                p_fluxnodeCache->mapDelegateToWrite.erase(item.first);
+            }
+        } else {
+            // Add to write map
+            if (p_fluxnodeCache) {
+                p_fluxnodeCache->mapDelegateToWrite[item.first] = item.second;
+                // Remove from erase set if it was there
+                p_fluxnodeCache->setDelegateToErase.erase(item.first);
+            }
+        }
     }
 
     if (fTxIndex)
@@ -4319,8 +4324,8 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
     // Update chainActive & related variables.
     UpdateTip(pindexNew, chainparams);
 
-    // Periodically check and shrink debug.log if needed (every 20000 blocks about 1 week in 30 second intervals)
-    // This checks actual file size against configurable threshold
+    // Periodically check and shrink debug.log if needed (every 20000 blocks, ~1 week at 30s intervals)
+    // Uses -maxdebugfilesize (threshold) and -debuglogretainsize (keep size) parameters
     if (pindexNew && GetBoolArg("-shrinkdebugfile", !fDebug) && pindexNew->nHeight % 20000 == 0) {
         ShrinkDebugFile();
     }


### PR DESCRIPTION
### Problem

  During PON (Proof of Node) consensus, multiple competing blocks at the same height can be valid. When the chain switches between competing blocks, a critical bug caused fluxnode cache corruption:

  1. Block A connects at height H → fluxnode undo data written to LevelDB (keyed by block hash)
  2. Block B (competing) replaces A → A disconnected, B connects with its own undo data
  3. `CleanupOldFluxnodeData()` runs → deletes A's undo data (A not in active chain)
  4. Block A reconnects (network switches back) → **NO new undo data written** because `BLOCK_HAVE_UNDO` flag is still set from step 1
  5. Block C replaces A → A disconnected, but undo data is **missing** → `lastConfirmedBlockHeight` values not restored → **cache corrupted**

  This resulted in nodes rejecting all subsequent blocks with errors like:
  VALIDATION FAILURE: Block rejection - COutPoint(...): currentHeight=X, lastConfirmed=X, distance=0, threshold=500

  ### Root Cause

  The fluxnode undo data write was inside a conditional block that only executed on first connection:
  ```cpp
  if (pindex->GetUndoPos().IsNull() || !pindex->IsValid(BLOCK_VALID_SCRIPTS))

  On reconnection, both conditions are false (flags set from first connection), so the entire block was skipped - including the fluxnode undo data write and delegate updates.

  Solution

  Moved the fluxnode undo data write and delegate updates outside the conditional block so they always execute when a block connects. This is correct because:

  1. Fluxnode undo data depends on the current chain state at connection time, which may differ from the original connection due to intermediate reorgs
  2. The data is keyed by block hash in LevelDB, so overwriting is safe
  3. The standard undo data (in rev*.dat) remains conditional since it's keyed by pindex position and doesn't change
