### PR TITLE
Batch write fluxnode db

### DIFF
--- a/src/fluxnode/fluxnode.cpp
+++ b/src/fluxnode/fluxnode.cpp
@@ -1520,6 +1520,61 @@ void FluxnodeCache::DumpFluxnodeCache()
     setDirtyDelegateErases.clear();
 }
 
+void FluxnodeCache::DumpFluxnodeCache(const uint256& bestBlockHash, int nBestBlockHeight)
+{
+    LOCK(cs);
+
+    // Use a batch for atomic writes - this ensures all fluxnode data and the sync state
+    // are written together. If crash occurs, either all writes succeed or none do.
+    CDBBatch batch(*pFluxnodeDB);
+
+    bool found = false;
+    for (const auto& item : setDirtyOutPoint) {
+        found = false;
+        if (mapStartTxTracker.count(item)) {
+            found = true;
+            pFluxnodeDB->WriteBatchFluxnodeData(batch, mapStartTxTracker.at(item));
+        } else if (mapStartTxDOSTracker.count(item)) {
+            found = true;
+            pFluxnodeDB->WriteBatchFluxnodeData(batch, mapStartTxDOSTracker.at(item));
+        } else if (mapConfirmedFluxnodeData.count(item)) {
+            found = true;
+            pFluxnodeDB->WriteBatchFluxnodeData(batch, mapConfirmedFluxnodeData.at(item));
+        }
+
+        if (!found) {
+            pFluxnodeDB->EraseBatchFluxnodeData(batch, item);
+        }
+    }
+
+    // Write dirty delegates to batch
+    for (const auto& item : mapDirtyDelegateWrites) {
+        pFluxnodeDB->WriteBatchDelegates(batch, item.first, item.second);
+    }
+
+    for (const auto& outpoint : setDirtyDelegateErases) {
+        pFluxnodeDB->EraseBatchDelegates(batch, outpoint);
+    }
+
+    // Write the sync state marker - this records what block height the fluxnode
+    // cache is synced to. Used for crash recovery detection at startup.
+    FluxnodeSyncState syncState(bestBlockHash, nBestBlockHeight);
+    pFluxnodeDB->WriteBatchSyncState(batch, syncState);
+
+    // Commit the batch atomically with sync for durability
+    if (pFluxnodeDB->WriteBatch(batch, true)) {
+        // Only clear dirty tracking structures after successful database write
+        setDirtyOutPoint.clear();
+        mapDirtyDelegateWrites.clear();
+        setDirtyDelegateErases.clear();
+
+        LogPrint("dfluxnode", "DumpFluxnodeCache: Synced to block %s at height %d\n",
+                 bestBlockHash.ToString(), nBestBlockHeight);
+    } else {
+        LogPrintf("ERROR: DumpFluxnodeCache: Failed to write batch to database\n");
+    }
+}
+
 bool IsFluxnodeTransactionsActive()
 {
     return chainActive.Height() >= Params().GetConsensus().vUpgrades[Consensus::UPGRADE_KAMATA].nActivationHeight;

--- a/src/fluxnode/fluxnode.h
+++ b/src/fluxnode/fluxnode.h
@@ -483,6 +483,7 @@ public:
     void EraseFromList(const std::set<COutPoint>& setToRemove, const Tier nTier);
 
     void DumpFluxnodeCache();
+    void DumpFluxnodeCache(const uint256& bestBlockHash, int nBestBlockHeight);
 
     // Delegate helper - checks cache first, then database
     bool GetDelegates(const COutPoint& outpoint, CFluxnodeDelegates& delegates);

--- a/src/fluxnode/fluxnodecachedb.cpp
+++ b/src/fluxnode/fluxnodecachedb.cpp
@@ -15,6 +15,7 @@
 static const char DB_FLUXNODE_CACHE_DATA = 'd';
 static const char BLOCK_FLUXNODE_UNDO_DATA = 'u';
 static const char FLUXNODE_DELEGATE_DATA = 'f';
+static const char DB_FLUXNODE_SYNC_STATE = 's';
 
 // EST 720 blocks * 7 Days
 static const int ONE_WEEK_OF_BLOCK_COUNT = 5040;
@@ -160,4 +161,39 @@ bool CDeterministicFluxnodeDB::CleanupOldFluxnodeData()
     }
 
     return true;
+}
+
+bool CDeterministicFluxnodeDB::WriteSyncState(const FluxnodeSyncState& syncState)
+{
+    return Write(DB_FLUXNODE_SYNC_STATE, syncState);
+}
+
+bool CDeterministicFluxnodeDB::ReadSyncState(FluxnodeSyncState& syncState)
+{
+    return Read(DB_FLUXNODE_SYNC_STATE, syncState);
+}
+
+void CDeterministicFluxnodeDB::WriteBatchFluxnodeData(CDBBatch& batch, const FluxnodeCacheData& data)
+{
+    batch.Write(std::make_pair(DB_FLUXNODE_CACHE_DATA, data.collateralIn), data);
+}
+
+void CDeterministicFluxnodeDB::EraseBatchFluxnodeData(CDBBatch& batch, const COutPoint& outpoint)
+{
+    batch.Erase(std::make_pair(DB_FLUXNODE_CACHE_DATA, outpoint));
+}
+
+void CDeterministicFluxnodeDB::WriteBatchDelegates(CDBBatch& batch, const COutPoint& outpoint, const CFluxnodeDelegates& delegates)
+{
+    batch.Write(std::make_pair(FLUXNODE_DELEGATE_DATA, outpoint), delegates);
+}
+
+void CDeterministicFluxnodeDB::EraseBatchDelegates(CDBBatch& batch, const COutPoint& outpoint)
+{
+    batch.Erase(std::make_pair(FLUXNODE_DELEGATE_DATA, outpoint));
+}
+
+void CDeterministicFluxnodeDB::WriteBatchSyncState(CDBBatch& batch, const FluxnodeSyncState& syncState)
+{
+    batch.Write(DB_FLUXNODE_SYNC_STATE, syncState);
 }

--- a/src/fluxnode/fluxnodecachedb.h
+++ b/src/fluxnode/fluxnodecachedb.h
@@ -10,12 +10,33 @@
 #define ZELCASH_FLUXNODECACHEDB_H
 
 #include "dbwrapper.h"
+#include "serialize.h"
+#include "uint256.h"
 #include <boost/filesystem/path.hpp>
 
 class FluxnodeCacheData;
 class COutPoint;
 class CFluxnodeTxBlockUndo;
 class CFluxnodeDelegates;
+
+/** Tracks the block height/hash that the fluxnode cache was last synced to.
+ *  Used to detect inconsistency between coins DB and fluxnode DB after crashes.
+ */
+struct FluxnodeSyncState {
+    uint256 bestBlockHash;
+    int nHeight;
+
+    FluxnodeSyncState() : nHeight(0) {}
+    FluxnodeSyncState(const uint256& hash, int height) : bestBlockHash(hash), nHeight(height) {}
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(bestBlockHash);
+        READWRITE(nHeight);
+    }
+};
 
 class CDeterministicFluxnodeDB : public CDBWrapper
 {
@@ -44,6 +65,16 @@ public:
 
     bool CleanupOldFluxnodeData();
 
+    // Sync state methods for crash recovery detection
+    bool WriteSyncState(const FluxnodeSyncState& syncState);
+    bool ReadSyncState(FluxnodeSyncState& syncState);
+
+    // Batch write support for atomic operations
+    void WriteBatchFluxnodeData(CDBBatch& batch, const FluxnodeCacheData& data);
+    void EraseBatchFluxnodeData(CDBBatch& batch, const COutPoint& outpoint);
+    void WriteBatchDelegates(CDBBatch& batch, const COutPoint& outpoint, const CFluxnodeDelegates& delegates);
+    void EraseBatchDelegates(CDBBatch& batch, const COutPoint& outpoint);
+    void WriteBatchSyncState(CDBBatch& batch, const FluxnodeSyncState& syncState);
 };
 
 #endif //ZELCASH_FLUXNODECACHEDB_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1633,7 +1633,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     }
 
     // Check fluxnode cache sync state for crash recovery detection
-    // If mismatch detected, shutdown and require reindex
+    // If mismatch detected, log a warning
     if (pFluxnodeDB && pcoinsTip && !fReindex) {
         FluxnodeSyncState fluxnodeSyncState;
         if (pFluxnodeDB->ReadSyncState(fluxnodeSyncState)) {
@@ -1642,14 +1642,12 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
             int coinsHeight = pindex ? pindex->nHeight : 0;
 
             if (fluxnodeSyncState.bestBlockHash != coinsBestBlock) {
-                return InitError(
-                    strprintf(_("Fluxnode cache is out of sync with blockchain state.\n"
-                               "  Fluxnode DB synced to: %s (height %d)\n"
-                               "  Coins DB best block:   %s (height %d)\n"
-                               "This likely occurred due to an unexpected shutdown or crash.\n"
-                               "Please restart with -reindex to rebuild the databases."),
-                              fluxnodeSyncState.bestBlockHash.ToString(), fluxnodeSyncState.nHeight,
-                              coinsBestBlock.ToString(), coinsHeight));
+                LogPrintf("WARNING: Fluxnode cache is out of sync with blockchain state.\n"
+                          "  Fluxnode DB synced to: %s (height %d)\n"
+                          "  Coins DB best block:   %s (height %d)\n"
+                          "  This may have occurred due to an unexpected shutdown or crash.\n",
+                          fluxnodeSyncState.bestBlockHash.ToString(), fluxnodeSyncState.nHeight,
+                          coinsBestBlock.ToString(), coinsHeight);
             } else {
                 LogPrint("dfluxnode", "Fluxnode cache sync state OK: %s (height %d)\n",
                         fluxnodeSyncState.bestBlockHash.ToString(), fluxnodeSyncState.nHeight);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -42,6 +42,7 @@
 #include "validationinterface.h"
 #include "fluxnode/fluxnodeconfig.h"
 #include "fluxnode/fluxnode.h"
+#include "fluxnode/fluxnodecachedb.h"
 #include "fluxnode/obfuscation.h"
 #include "fluxnode/activefluxnode.h"
 #include "snapshot/snapshotdb.h"
@@ -1628,6 +1629,33 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
             } else {
                 return InitError(strLoadError);
             }
+        }
+    }
+
+    // Check fluxnode cache sync state for crash recovery detection
+    // If mismatch detected, shutdown and require reindex
+    if (pFluxnodeDB && pcoinsTip && !fReindex) {
+        FluxnodeSyncState fluxnodeSyncState;
+        if (pFluxnodeDB->ReadSyncState(fluxnodeSyncState)) {
+            uint256 coinsBestBlock = pcoinsTip->GetBestBlock();
+            CBlockIndex* pindex = chainActive.Tip();
+            int coinsHeight = pindex ? pindex->nHeight : 0;
+
+            if (fluxnodeSyncState.bestBlockHash != coinsBestBlock) {
+                return InitError(
+                    strprintf(_("Fluxnode cache is out of sync with blockchain state.\n"
+                               "  Fluxnode DB synced to: %s (height %d)\n"
+                               "  Coins DB best block:   %s (height %d)\n"
+                               "This likely occurred due to an unexpected shutdown or crash.\n"
+                               "Please restart with -reindex to rebuild the databases."),
+                              fluxnodeSyncState.bestBlockHash.ToString(), fluxnodeSyncState.nHeight,
+                              coinsBestBlock.ToString(), coinsHeight));
+            } else {
+                LogPrint("dfluxnode", "Fluxnode cache sync state OK: %s (height %d)\n",
+                        fluxnodeSyncState.bestBlockHash.ToString(), fluxnodeSyncState.nHeight);
+            }
+        } else {
+            LogPrint("dfluxnode", "No fluxnode sync state found (first run or pre-upgrade database)\n");
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -167,17 +167,9 @@ namespace {
                 uint256 ponHashB = GetPONHash(pb->GetBlockHeader());
 
                 if (ponHashA < ponHashB) {
-                    LogPrint("pon", "PON tie-breaker: Block %s (PON hash %s) wins over %s (PON hash %s) at height %d\n",
-                             pa->GetBlockHash().ToString().substr(0,12).c_str(), ponHashA.ToString().substr(0,12).c_str(),
-                             pb->GetBlockHash().ToString().substr(0,12).c_str(), ponHashB.ToString().substr(0,12).c_str(),
-                             pa->nHeight);
                     return false; // A has better (lower) hash, A wins
                 }
                 if (ponHashA > ponHashB) {
-                    LogPrint("pon", "PON tie-breaker: Block %s (PON hash %s) wins over %s (PON hash %s) at height %d\n",
-                             pb->GetBlockHash().ToString().substr(0,12).c_str(), ponHashB.ToString().substr(0,12).c_str(),
-                             pa->GetBlockHash().ToString().substr(0,12).c_str(), ponHashA.ToString().substr(0,12).c_str(),
-                             pb->nHeight);
                     return true;  // B has better (lower) hash, B wins
                 }
                 // If hashes are equal, fall through to sequence ID
@@ -4094,8 +4086,14 @@ bool static FlushStateToDisk(CValidationState &state, FlushStateMode mode) {
         if (!pcoinsTip->Flush())
             return AbortNode(state, "Failed to write to coin database");
 
-        // Dump Fluxnode cache to database
-        g_fluxnodeCache.DumpFluxnodeCache();
+        // Dump Fluxnode cache to database with sync state marker
+        // This uses atomic batch writes to ensure consistency between
+        // fluxnode data and the sync state marker
+        if (chainActive.Tip()) {
+            g_fluxnodeCache.DumpFluxnodeCache(chainActive.Tip()->GetBlockHash(), chainActive.Height());
+        } else {
+            g_fluxnodeCache.DumpFluxnodeCache();
+        }
         nLastFlush = nNow;
     }
     if ((mode == FLUSH_STATE_ALWAYS || mode == FLUSH_STATE_PERIODIC) && nNow > nLastSetChain + (int64_t)DATABASE_WRITE_INTERVAL * 1000000) {


### PR DESCRIPTION
- Batch write fluxnode data to db now
- Allow the software to stop from running if it is in a bad state. 