### PR TITLE
listfluxnodedelegates rpc

### DIFF
--- a/src/fluxnode/fluxnodecachedb.cpp
+++ b/src/fluxnode/fluxnodecachedb.cpp
@@ -91,8 +91,8 @@ bool CDeterministicFluxnodeDB::ReadFluxnodeDelegates(const COutPoint& outpoint, 
     if (Exists(std::make_pair(FLUXNODE_DELEGATE_DATA, outpoint)))
         return Read(std::make_pair(FLUXNODE_DELEGATE_DATA, outpoint), delegates);
 
-    // If it doesn't exist, we just return true because we don't want to fail just because it didn't exist in the db
-    return true;
+    // If it doesn't exist, return false to indicate no delegates found
+    return false;
 }
 
 bool CDeterministicFluxnodeDB::EraseFluxnodeDelegate(const COutPoint& outpoint)

--- a/src/rpc/fluxnode.cpp
+++ b/src/rpc/fluxnode.cpp
@@ -1300,6 +1300,91 @@ UniValue startp2shasdelegate(const UniValue& params, bool fHelp)
     return returnObj;
 }
 
+UniValue listfluxnodedelegates(const UniValue& params, bool fHelp)
+{
+    if (!IsFluxnodeTransactionsActive()) {
+        throw runtime_error("deterministic fluxnodes transactions is not active yet");
+    }
+
+    if (fHelp || params.size() != 2)
+        throw runtime_error(
+                "listfluxnodedelegates \"txhash\" \"outputindex\"\n"
+                "\nList delegate keys authorized for a specific fluxnode collateral.\n"
+                "\nArguments:\n"
+                "1. txhash         (string, required) The transaction hash of the collateral.\n"
+                "2. outputindex    (string, required) The output index of the collateral.\n"
+                "\nResult:\n"
+                "{\n"
+                "  \"collateral\": \"xxxx:n\",           (string) Collateral outpoint\n"
+                "  \"has_delegates\": true|false,        (boolean) Whether delegates are registered\n"
+                "  \"delegate_version\": n,              (numeric) Delegate data version\n"
+                "  \"delegate_type\": n,                 (numeric) Delegate type (1=UPDATE/ALL, 2=SIGNING)\n"
+                "  \"delegate_type_string\": \"xxxx\",   (string) Delegate type as string\n"
+                "  \"delegate_keys\": [                  (array) Array of authorized delegate public keys\n"
+                "    \"key\",                            (string) Compressed public key (hex)\n"
+                "    ...\n"
+                "  ]\n"
+                "}\n"
+                "\nExamples:\n" +
+                HelpExampleCli("listfluxnodedelegates", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\" \"0\"") +
+                HelpExampleRpc("listfluxnodedelegates", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\", \"0\""));
+
+    std::string strTxHash = params[0].get_str();
+    std::string strOutputIndex = params[1].get_str();
+
+    UniValue returnObj(UniValue::VOBJ);
+
+    // Validate the transaction hash
+    uint256 txHash = uint256S(strTxHash);
+    if (txHash.IsNull()) {
+        returnObj.pushKV("error", "Invalid transaction hash");
+        return returnObj;
+    }
+
+    // Validate the output index
+    int nOutputIndex;
+    try {
+        nOutputIndex = std::stoi(strOutputIndex);
+    } catch (const std::exception& e) {
+        returnObj.pushKV("error", "Invalid output index");
+        return returnObj;
+    }
+
+    COutPoint outpoint(txHash, nOutputIndex);
+
+    returnObj.pushKV("collateral", outpoint.ToFullString());
+
+    // Try to get delegates for this outpoint
+    CFluxnodeDelegates delegates;
+    bool hasDelegates = g_fluxnodeCache.GetDelegates(outpoint, delegates);
+
+    returnObj.pushKV("has_delegates", hasDelegates);
+
+    if (hasDelegates && delegates.IsValid()) {
+        returnObj.pushKV("delegate_version", delegates.nDelegateVersion);
+        returnObj.pushKV("delegate_type", delegates.nType);
+
+        std::string typeString;
+        if (delegates.nType == CFluxnodeDelegates::UPDATE) {
+            typeString = "UPDATE";
+        } else if (delegates.nType == CFluxnodeDelegates::SIGNING) {
+            typeString = "SIGNING";
+        } else {
+            typeString = "UNKNOWN";
+        }
+        returnObj.pushKV("delegate_type_string", typeString);
+
+        // Add delegate keys array
+        UniValue keysArray(UniValue::VARR);
+        for (const auto& pubkey : delegates.delegateStartingKeys) {
+            keysArray.push_back(HexStr(pubkey));
+        }
+        returnObj.pushKV("delegate_keys", keysArray);
+    }
+
+    return returnObj;
+}
+
 void GetDeterministicListData(UniValue& listData, const std::string& strFilter, const Tier tier) {
     int count = -1;
     for (const auto& item : g_fluxnodeCache.mapFluxnodeList.at(tier).listConfirmedFluxnodes) {
@@ -2446,6 +2531,7 @@ static const CRPCCommand commands[] =
                 { "fluxnode",   "startfluxnodewithdelegates", &startfluxnodewithdelegates, false },
                 { "fluxnode",   "startfluxnodeasdelegate", &startfluxnodeasdelegate, false },
                 { "fluxnode",   "startp2shasdelegate", &startp2shasdelegate, false },
+                { "fluxnode",   "listfluxnodedelegates", &listfluxnodedelegates, false },
                 { "fluxnode",   "viewdeterministicfluxnodelist", &viewdeterministicfluxnodelist, false },
 
                 { "benchmarks", "getbenchmarks",         &getbenchmarks,           false  },

--- a/src/rpc/fluxnode.cpp
+++ b/src/rpc/fluxnode.cpp
@@ -1329,12 +1329,15 @@ UniValue listfluxnodedelegates(const UniValue& params, bool fHelp)
                 HelpExampleCli("listfluxnodedelegates", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\" \"0\"") +
                 HelpExampleRpc("listfluxnodedelegates", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\", \"0\""));
 
-    std::string strTxHash = params[0].get_str();
-    std::string strOutputIndex = params[1].get_str();
-
     UniValue returnObj(UniValue::VOBJ);
 
     // Validate the transaction hash
+    std::string strTxHash = params[0].get_str();
+    if (!IsHex(strTxHash) || strTxHash.length() != 64) {
+        returnObj.pushKV("error", "Invalid transaction hash (must be 64 hex characters)");
+        return returnObj;
+    }
+
     uint256 txHash = uint256S(strTxHash);
     if (txHash.IsNull()) {
         returnObj.pushKV("error", "Invalid transaction hash");
@@ -1342,9 +1345,16 @@ UniValue listfluxnodedelegates(const UniValue& params, bool fHelp)
     }
 
     // Validate the output index
-    int nOutputIndex;
+    std::string strOutputIndex = params[1].get_str();
+    uint32_t nOutputIndex;
+
     try {
-        nOutputIndex = std::stoi(strOutputIndex);
+        unsigned long idx = std::stoul(strOutputIndex);
+        if (idx > 0xFFFFFFFF) {
+            returnObj.pushKV("error", "Output index exceeds maximum (4294967295)");
+            return returnObj;
+        }
+        nOutputIndex = static_cast<uint32_t>(idx);
     } catch (const std::exception& e) {
         returnObj.pushKV("error", "Invalid output index");
         return returnObj;


### PR DESCRIPTION
New RPC endpoint to see if an Outpoint has delegates. Uses the same style as other methods in `fluxnode.cpp`

<img width="1890" height="868" alt="Screenshot 2026-01-20 at 8 10 36 AM" src="https://github.com/user-attachments/assets/141c68e6-65f9-408e-a9c1-f2e86b1fe7c9" />
