### PR TITLE
fix: port Bitcoin Core network resilience to prevent p2p stalls

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -80,6 +80,7 @@ BITCOIN_TESTS =\
   test/multisig_tests.cpp \
   test/netbase_tests.cpp \
   test/net_reseed_tests.cpp \
+  test/net_timeout_tests.cpp \
   test/pmt_tests.cpp \
   test/policyestimator_tests.cpp \
   test/pow_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -79,6 +79,7 @@ BITCOIN_TESTS =\
   test/mruset_tests.cpp \
   test/multisig_tests.cpp \
   test/netbase_tests.cpp \
+  test/net_reseed_tests.cpp \
   test/pmt_tests.cpp \
   test/policyestimator_tests.cpp \
   test/pow_tests.cpp \

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -213,6 +213,7 @@ void CAddrMan::Good_(const CService& addr, int64_t nTime)
     info.nLastSuccess = nTime;
     info.nLastTry = nTime;
     info.nAttempts = 0;
+    m_last_good = nTime;
     // nTime is not updated here, to avoid leaking information about
     // currently-connected peers.
 
@@ -327,7 +328,13 @@ void CAddrMan::Attempt_(const CService& addr, int64_t nTime)
 
     // update info
     info.nLastTry = nTime;
-    info.nAttempts++;
+    // Only count attempt as failure if no successful connection has happened
+    // since last count (Bitcoin Core PR #11560 — prevents penalty spiral
+    // during network blips)
+    if (info.nLastCountAttempt < m_last_good) {
+        info.nLastCountAttempt = nTime;
+        info.nAttempts++;
+    }
 }
 
 CAddrInfo CAddrMan::Select_(bool newOnly)

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -334,6 +334,8 @@ void CAddrMan::Attempt_(const CService& addr, int64_t nTime)
     if (info.nLastCountAttempt < m_last_good) {
         info.nLastCountAttempt = nTime;
         info.nAttempts++;
+    } else {
+        LogPrint("addrman", "Suppressed attempt penalty for %s (failure epoch unchanged)\n", addr.ToString());
     }
 }
 

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -213,7 +213,7 @@ void CAddrMan::Good_(const CService& addr, int64_t nTime)
     info.nLastSuccess = nTime;
     info.nLastTry = nTime;
     info.nAttempts = 0;
-    m_last_good = nTime;
+    m_last_good++;
     // nTime is not updated here, to avoid leaking information about
     // currently-connected peers.
 
@@ -332,7 +332,7 @@ void CAddrMan::Attempt_(const CService& addr, int64_t nTime)
     // since last count (Bitcoin Core PR #11560 — prevents penalty spiral
     // during network blips)
     if (info.nLastCountAttempt < m_last_good) {
-        info.nLastCountAttempt = nTime;
+        info.nLastCountAttempt = m_last_good;
         info.nAttempts++;
     } else {
         LogPrint("addrman", "Suppressed attempt penalty for %s (failure epoch unchanged)\n", addr.ToString());

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -29,7 +29,7 @@ public:
     //! last try whatsoever by us (memory only)
     int64_t nLastTry;
 
-    //! last time this addr incremented nAttempts (memory only)
+    //! epoch at which this addr last incremented nAttempts (memory only)
     int64_t nLastCountAttempt;
 
 private:
@@ -207,7 +207,7 @@ private:
     //! list of "new" buckets
     int vvNew[ADDRMAN_NEW_BUCKET_COUNT][ADDRMAN_BUCKET_SIZE];
 
-    //! timestamp of last successful inbound/outbound connection (memory only)
+    //! epoch counter incremented on each Good_() call (memory only)
     int64_t m_last_good;
 
 protected:

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -29,6 +29,9 @@ public:
     //! last try whatsoever by us (memory only)
     int64_t nLastTry;
 
+    //! last time this addr incremented nAttempts (memory only)
+    int64_t nLastCountAttempt;
+
 private:
     //! where knowledge about this address first came from
     CNetAddr source;
@@ -66,6 +69,7 @@ public:
     {
         nLastSuccess = 0;
         nLastTry = 0;
+        nLastCountAttempt = 0;
         nAttempts = 0;
         nRefCount = 0;
         fInTried = false;
@@ -102,6 +106,9 @@ public:
 
     //! Calculate the relative chance this entry should be given when selecting nodes to connect to
     double GetChance(int64_t nNow = GetAdjustedTime()) const;
+
+    //! Return number of connection attempts since last success
+    int GetAttempts() const { return nAttempts; }
 
 };
 
@@ -199,6 +206,9 @@ private:
 
     //! list of "new" buckets
     int vvNew[ADDRMAN_NEW_BUCKET_COUNT][ADDRMAN_BUCKET_SIZE];
+
+    //! timestamp of last successful inbound/outbound connection (memory only)
+    int64_t m_last_good;
 
 protected:
     //! secret key to randomize bucket select with
@@ -453,6 +463,7 @@ public:
         nIdCount = 0;
         nTried = 0;
         nNew = 0;
+        m_last_good = 1;
     }
 
     CAddrMan()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6806,6 +6806,12 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         pfrom->fSuccessfullyConnected = true;
 
+        if (pfrom->fFeeler) {
+            // Feeler connection succeeded — address is verified good, disconnect
+            pfrom->fDisconnect = true;
+            return true;
+        }
+
         string remoteAddr;
         if (fLogIPs)
             remoteAddr = ", peeraddr=" + pfrom->addr.ToString();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6808,6 +6808,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         if (pfrom->fFeeler) {
             // Feeler connection succeeded — address is verified good, disconnect
+            LogPrint("net", "Feeler connection to %s succeeded, disconnecting\n", pfrom->addr.ToString());
             pfrom->fDisconnect = true;
             return true;
         }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1290,54 +1290,6 @@ void ThreadDNSAddressSeed()
     LogPrintf("%d addresses found from DNS seeds\n", found);
 }
 
-static int64_t nLastReseed = 0;
-static bool fPeerLossDetected = false;
-
-static void DNSReseedIfNeeded()
-{
-    // Only reseed if we have very few outbound peers
-    int nOutbound = 0;
-    {
-        LOCK(cs_vNodes);
-        BOOST_FOREACH(CNode* pnode, vNodes) {
-            if (!pnode->fInbound && !pnode->fOneShot && !pnode->fDisconnect)
-                nOutbound++;
-        }
-    }
-    if (nOutbound >= 2) {
-        if (fPeerLossDetected) {
-            LogPrintf("Network recovery: outbound peers restored to %d\n", nOutbound);
-            fPeerLossDetected = false;
-        }
-        return;
-    }
-    fPeerLossDetected = true;
-
-    int64_t nNow = GetTime();
-    if (nNow - nLastReseed < 120) // 2-minute cooldown
-        return;
-    nLastReseed = nNow;
-
-    LogPrintf("DNSReseedIfNeeded: only %d outbound peers, re-querying DNS seeds\n", nOutbound);
-
-    const vector<CDNSSeedData>& vSeeds = Params().DNSSeeds();
-    int nFound = 0;
-    BOOST_FOREACH(const CDNSSeedData& seed, vSeeds) {
-        vector<CNetAddr> vIPs;
-        vector<CAddress> vAdd;
-        if (LookupHost(seed.host.c_str(), vIPs, 256, true)) {
-            BOOST_FOREACH(const CNetAddr& ip, vIPs) {
-                CAddress addr = CAddress(CService(ip, Params().GetDefaultPort()));
-                addr.nTime = GetTime();
-                vAdd.push_back(addr);
-                nFound++;
-            }
-        }
-        addrman.Add(vAdd, CNetAddr(seed.name, true));
-    }
-    LogPrintf("DNSReseedIfNeeded: added %d addresses from DNS seeds\n", nFound);
-}
-
 static const int STALE_TIP_PROBE_SECONDS = 180;   // 3 minutes without a new block triggers probing
 static const int STALE_TIP_PROBE_INTERVAL = 60;   // re-probe every 60 seconds while tip is stale
 static const int STALE_TIP_PING_TIMEOUT  = 30;    // 30 seconds to answer a probe ping
@@ -1479,8 +1431,6 @@ void ThreadOpenConnections()
     while (true)
     {
         ProcessOneShot();
-
-        DNSReseedIfNeeded();
 
         MilliSleep(500);
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1338,6 +1338,90 @@ static void DNSReseedIfNeeded()
     LogPrintf("DNSReseedIfNeeded: added %d addresses from DNS seeds\n", nFound);
 }
 
+static const int STALE_TIP_PROBE_SECONDS = 180;   // 3 minutes without a new block triggers probing
+static const int STALE_TIP_PROBE_INTERVAL = 60;   // re-probe every 60 seconds while tip is stale
+static const int STALE_TIP_PING_TIMEOUT  = 30;    // 30 seconds to answer a probe ping
+
+static void CheckStaleTip()
+{
+    // Track when chain height last changed
+    static int nLastTipHeight = 0;
+    static int64_t nLastTipChange = 0;
+    static int64_t nLastProbe = 0;
+
+    int height;
+    {
+        LOCK(cs_main);
+        height = chainActive.Height();
+    }
+
+    int64_t nNow = GetTime();
+
+    // Tip advanced — reset everything
+    if (height != nLastTipHeight) {
+        nLastTipHeight = height;
+        nLastTipChange = nNow;
+        nLastProbe = 0;
+        return;
+    }
+
+    // Initialize on first call
+    if (nLastTipChange == 0) {
+        nLastTipChange = nNow;
+        nLastTipHeight = height;
+        return;
+    }
+
+    int64_t nStaleSeconds = nNow - nLastTipChange;
+    if (nStaleSeconds < STALE_TIP_PROBE_SECONDS)
+        return;
+
+    // Time to send new probes? (every STALE_TIP_PROBE_INTERVAL while stale)
+    if (nNow - nLastProbe >= STALE_TIP_PROBE_INTERVAL) {
+        int nProbed = 0;
+        {
+            LOCK(cs_vNodes);
+            BOOST_FOREACH(CNode* pnode, vNodes) {
+                if (pnode->fInbound || pnode->fOneShot || pnode->fDisconnect)
+                    continue;
+                pnode->fPingQueued = true;
+                nProbed++;
+            }
+        }
+        if (nProbed > 0) {
+            LogPrintf("Stale tip (height %d, %ds old): probing %d outbound peers\n",
+                      height, nStaleSeconds, nProbed);
+        }
+        nLastProbe = nNow;
+        return;
+    }
+
+    // Check for zombies: 30s after probes were sent, any unanswered ping = zombie
+    if (nNow - nLastProbe >= STALE_TIP_PING_TIMEOUT) {
+        int nZombie = 0;
+        int nOutbound = 0;
+        {
+            LOCK(cs_vNodes);
+            BOOST_FOREACH(CNode* pnode, vNodes) {
+                if (pnode->fInbound || pnode->fOneShot || pnode->fDisconnect)
+                    continue;
+                nOutbound++;
+                if (pnode->nPingNonceSent != 0 &&
+                    pnode->nPingUsecStart + STALE_TIP_PING_TIMEOUT * 1000000LL < GetTimeMicros()) {
+                    LogPrintf("Stale tip: peer %s ping unanswered for %ds, disconnecting\n",
+                              pnode->addr.ToString(),
+                              (int)((GetTimeMicros() - pnode->nPingUsecStart) / 1000000));
+                    pnode->fDisconnect = true;
+                    nZombie++;
+                }
+            }
+        }
+        if (nZombie > 0) {
+            LogPrintf("Stale tip: disconnected %d/%d zombie outbound peers\n", nZombie, nOutbound);
+        }
+    }
+}
+
 void DumpAddresses()
 {
     int64_t nStart = GetTimeMillis();
@@ -1397,6 +1481,7 @@ void ThreadOpenConnections()
         ProcessOneShot();
 
         DNSReseedIfNeeded();
+        CheckStaleTip();
 
         MilliSleep(500);
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1496,11 +1496,7 @@ void ThreadOpenConnections()
                 grant.Release();
                 CSemaphoreGrant feelerGrant(*semOutbound, true);
                 if (feelerGrant) {
-                    OpenNetworkConnection(addrConnect, &feelerGrant);
-                    // Mark the node as a feeler so it disconnects after handshake
-                    CNode* pfeeler = FindNode(addrConnect.ToStringIPPort());
-                    if (pfeeler)
-                        pfeeler->fFeeler = true;
+                    OpenNetworkConnection(addrConnect, &feelerGrant, NULL, false, true);
                 }
             } else {
                 OpenNetworkConnection(addrConnect, &grant);
@@ -1581,7 +1577,7 @@ void ThreadOpenAddedConnections()
 }
 
 // if successful, this moves the passed grant to the constructed node
-bool OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGrant *grantOutbound, const char *pszDest, bool fOneShot)
+bool OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGrant *grantOutbound, const char *pszDest, bool fOneShot, bool fFeeler)
 {
     //
     // Initiate outbound network connection
@@ -1605,6 +1601,8 @@ bool OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGrant *grantOu
     pnode->fNetworkNode = true;
     if (fOneShot)
         pnode->fOneShot = true;
+    if (fFeeler)
+        pnode->fFeeler = true;
 
     return true;
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1291,6 +1291,7 @@ void ThreadDNSAddressSeed()
 }
 
 static int64_t nLastReseed = 0;
+static bool fPeerLossDetected = false;
 
 static void DNSReseedIfNeeded()
 {
@@ -1303,8 +1304,14 @@ static void DNSReseedIfNeeded()
                 nOutbound++;
         }
     }
-    if (nOutbound >= 2)
+    if (nOutbound >= 2) {
+        if (fPeerLossDetected) {
+            LogPrintf("Network recovery: outbound peers restored to %d\n", nOutbound);
+            fPeerLossDetected = false;
+        }
         return;
+    }
+    fPeerLossDetected = true;
 
     int64_t nNow = GetTime();
     if (nNow - nLastReseed < 120) // 2-minute cooldown

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1481,7 +1481,6 @@ void ThreadOpenConnections()
         ProcessOneShot();
 
         DNSReseedIfNeeded();
-        CheckStaleTip();
 
         MilliSleep(500);
 
@@ -1755,6 +1754,9 @@ void ThreadMessageHandler()
             BOOST_FOREACH(CNode* pnode, vNodesCopy)
                 pnode->Release();
         }
+
+        // Check for stale tip / zombie peers (runs on its own internal timers)
+        CheckStaleTip();
 
         if (fSleep)
             messageHandlerCondition.timed_wait(lock, boost::posix_time::microsec_clock::universal_time() + boost::posix_time::milliseconds(100));

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -98,6 +98,9 @@ CCriticalSection cs_nLastNodeId;
 static CSemaphore *semOutbound = NULL;
 static boost::condition_variable messageHandlerCondition;
 
+static std::vector<CAddress> vAnchorAddresses;
+static const size_t MAX_ANCHOR_CONNECTIONS = 2;
+
 // Signals for message handling
 static CNodeSignals g_signals;
 CNodeSignals& GetNodeSignals() { return g_signals; }
@@ -1287,16 +1290,46 @@ void ThreadDNSAddressSeed()
     LogPrintf("%d addresses found from DNS seeds\n", found);
 }
 
+static int64_t nLastReseed = 0;
 
+static void DNSReseedIfNeeded()
+{
+    // Only reseed if we have very few outbound peers
+    int nOutbound = 0;
+    {
+        LOCK(cs_vNodes);
+        BOOST_FOREACH(CNode* pnode, vNodes) {
+            if (!pnode->fInbound && !pnode->fOneShot && !pnode->fDisconnect)
+                nOutbound++;
+        }
+    }
+    if (nOutbound >= 2)
+        return;
 
+    int64_t nNow = GetTime();
+    if (nNow - nLastReseed < 120) // 2-minute cooldown
+        return;
+    nLastReseed = nNow;
 
+    LogPrintf("DNSReseedIfNeeded: only %d outbound peers, re-querying DNS seeds\n", nOutbound);
 
-
-
-
-
-
-
+    const vector<CDNSSeedData>& vSeeds = Params().DNSSeeds();
+    int nFound = 0;
+    BOOST_FOREACH(const CDNSSeedData& seed, vSeeds) {
+        vector<CNetAddr> vIPs;
+        vector<CAddress> vAdd;
+        if (LookupHost(seed.host.c_str(), vIPs, 256, true)) {
+            BOOST_FOREACH(const CNetAddr& ip, vIPs) {
+                CAddress addr = CAddress(CService(ip, Params().GetDefaultPort()));
+                addr.nTime = GetTime();
+                vAdd.push_back(addr);
+                nFound++;
+            }
+        }
+        addrman.Add(vAdd, CNetAddr(seed.name, true));
+    }
+    LogPrintf("DNSReseedIfNeeded: added %d addresses from DNS seeds\n", nFound);
+}
 
 void DumpAddresses()
 {
@@ -1350,9 +1383,13 @@ void ThreadOpenConnections()
 
     // Initiate network connections
     int64_t nStart = GetTime();
+    static int64_t nNextFeeler = 0;
+    static const int64_t FEELER_INTERVAL = 120;
     while (true)
     {
         ProcessOneShot();
+
+        DNSReseedIfNeeded();
 
         MilliSleep(500);
 
@@ -1369,10 +1406,20 @@ void ThreadOpenConnections()
             }
         }
 
+        // Try anchor connections first (Bitcoin Core PR #17428)
+        if (!vAnchorAddresses.empty()) {
+            CAddress addr = vAnchorAddresses.back();
+            vAnchorAddresses.pop_back();
+            LogPrintf("Trying anchor connection to %s\n", addr.ToString());
+            OpenNetworkConnection(addr, &grant);
+            continue;
+        }
+
         //
         // Choose an address to connect to based on most recently seen
         //
         CAddress addrConnect;
+        bool fFeeler = false;
 
         // Only connect out to one peer per network group (/16 for IPv4).
         // Do this here so we don't have to critsect vNodes inside mapAddresses critsect.
@@ -1388,12 +1435,20 @@ void ThreadOpenConnections()
             }
         }
 
+        // Feeler connections: periodically test an untried address to keep
+        // the address table fresh (Bitcoin Core PR #8282)
+        int64_t nNow = GetTime();
+        if (nNow > nNextFeeler) {
+            nNextFeeler = nNow + FEELER_INTERVAL;
+            fFeeler = true;
+        }
+
         int64_t nANow = GetAdjustedTime();
 
         int nTries = 0;
         while (true)
         {
-            CAddrInfo addr = addrman.Select();
+            CAddrInfo addr = addrman.Select(fFeeler);
 
             // if we selected an invalid address, restart
             if (!addr.IsValid() || setConnected.count(addr.GetGroup()) || IsLocal(addr))
@@ -1409,6 +1464,12 @@ void ThreadOpenConnections()
             if (IsLimited(addr))
                 continue;
 
+            // for feeler connections, skip the recently-tried and port filters
+            if (fFeeler) {
+                addrConnect = addr;
+                break;
+            }
+
             // only consider very recently tried nodes after 30 failed attempts
             if (nANow - addr.nLastTry < 600 && nTries < 30)
                 continue;
@@ -1421,8 +1482,23 @@ void ThreadOpenConnections()
             break;
         }
 
-        if (addrConnect.IsValid())
-            OpenNetworkConnection(addrConnect, &grant);
+        if (addrConnect.IsValid()) {
+            if (fFeeler) {
+                // Feeler: use a non-blocking grant so we don't consume a
+                // connection slot if all are in use
+                grant.Release();
+                CSemaphoreGrant feelerGrant(*semOutbound, true);
+                if (feelerGrant) {
+                    OpenNetworkConnection(addrConnect, &feelerGrant);
+                    // Mark the node as a feeler so it disconnects after handshake
+                    CNode* pfeeler = FindNode(addrConnect.ToStringIPPort());
+                    if (pfeeler)
+                        pfeeler->fFeeler = true;
+                }
+            } else {
+                OpenNetworkConnection(addrConnect, &grant);
+            }
+        }
     }
 }
 
@@ -1766,6 +1842,16 @@ void StartNode(boost::thread_group& threadGroup, CScheduler& scheduler)
            addrman.size(), GetTimeMillis() - nStart);
     fAddressesInitialized = true;
 
+    // Load anchor addresses for fast reconnection after restart
+    {
+        CAnchorDB anchordb;
+        if (anchordb.Read(vAnchorAddresses)) {
+            if (vAnchorAddresses.size() > MAX_ANCHOR_CONNECTIONS)
+                vAnchorAddresses.resize(MAX_ANCHOR_CONNECTIONS);
+            LogPrintf("Loaded %d anchor addresses from anchors.dat\n", vAnchorAddresses.size());
+        }
+    }
+
     if (semOutbound == NULL) {
         // initialize semaphore
         int nMaxOutbound = min(MAX_OUTBOUND_CONNECTIONS, nMaxConnections);
@@ -1811,6 +1897,25 @@ bool StopNode()
 
     if (fAddressesInitialized)
     {
+        // Save best outbound peers as anchors for fast reconnection
+        {
+            std::vector<CAddress> anchors;
+            LOCK(cs_vNodes);
+            BOOST_FOREACH(CNode* pnode, vNodes) {
+                if (!pnode->fInbound && !pnode->fOneShot && !pnode->fDisconnect &&
+                    pnode->fSuccessfullyConnected) {
+                    anchors.push_back(pnode->addr);
+                    if (anchors.size() >= MAX_ANCHOR_CONNECTIONS)
+                        break;
+                }
+            }
+            if (!anchors.empty()) {
+                CAnchorDB anchordb;
+                anchordb.Write(anchors);
+                LogPrintf("Saved %d anchor addresses to anchors.dat\n", anchors.size());
+            }
+        }
+
         DumpAddresses();
         fAddressesInitialized = false;
     }
@@ -2084,6 +2189,109 @@ bool CAddrDB::Read(CAddrMan& addr)
     return true;
 }
 
+//
+// CAnchorDB
+//
+
+CAnchorDB::CAnchorDB()
+{
+    pathAnchor = GetDataDir() / "anchors.dat";
+}
+
+bool CAnchorDB::Write(const std::vector<CAddress>& anchors)
+{
+    // Generate random temporary filename
+    unsigned short randv = 0;
+    GetRandBytes((unsigned char*)&randv, sizeof(randv));
+    std::string tmpfn = strprintf("anchors.dat.%04x", randv);
+
+    // serialize addresses, checksum data up to that point, then append csum
+    CDataStream ss(SER_DISK, CLIENT_VERSION);
+    ss << FLATDATA(Params().MessageStart());
+    ss << anchors;
+    uint256 hash = Hash(ss.begin(), ss.end());
+    ss << hash;
+
+    // open temp output file, and associate with CAutoFile
+    boost::filesystem::path pathTmp = GetDataDir() / tmpfn;
+    FILE *file = fopen(pathTmp.string().c_str(), "wb");
+    CAutoFile fileout(file, SER_DISK, CLIENT_VERSION);
+    if (fileout.IsNull())
+        return error("%s: Failed to open file %s", __func__, pathTmp.string());
+
+    // Write and commit header, data
+    try {
+        fileout << ss;
+    }
+    catch (const std::exception& e) {
+        return error("%s: Serialize or I/O error - %s", __func__, e.what());
+    }
+    FileCommit(fileout.Get());
+    fileout.fclose();
+
+    // replace existing anchors.dat, if any, with new anchors.dat.XXXX
+    if (!RenameOver(pathTmp, pathAnchor))
+        return error("%s: Rename-into-place failed", __func__);
+
+    return true;
+}
+
+bool CAnchorDB::Read(std::vector<CAddress>& anchors)
+{
+    // open input file, and associate with CAutoFile
+    FILE *file = fopen(pathAnchor.string().c_str(), "rb");
+    CAutoFile filein(file, SER_DISK, CLIENT_VERSION);
+    if (filein.IsNull())
+        return error("%s: Failed to open file %s", __func__, pathAnchor.string());
+
+    // use file size to size memory buffer
+    int fileSize = boost::filesystem::file_size(pathAnchor);
+    int dataSize = fileSize - sizeof(uint256);
+    if (dataSize < 0)
+        dataSize = 0;
+    vector<unsigned char> vchData;
+    vchData.resize(dataSize);
+    uint256 hashIn;
+
+    // read data and checksum from file
+    try {
+        filein.read((char *)&vchData[0], dataSize);
+        filein >> hashIn;
+    }
+    catch (const std::exception& e) {
+        return error("%s: Deserialize or I/O error - %s", __func__, e.what());
+    }
+    filein.fclose();
+
+    CDataStream ss(vchData, SER_DISK, CLIENT_VERSION);
+
+    // verify stored checksum matches input data
+    uint256 hashTmp = Hash(ss.begin(), ss.end());
+    if (hashIn != hashTmp)
+        return error("%s: Checksum mismatch, data corrupted", __func__);
+
+    unsigned char pchMsgTmp[4];
+    try {
+        // de-serialize file header (network specific magic number)
+        ss >> FLATDATA(pchMsgTmp);
+
+        // verify the network matches ours
+        if (memcmp(pchMsgTmp, Params().MessageStart(), sizeof(pchMsgTmp)))
+            return error("%s: Invalid network magic number", __func__);
+
+        // de-serialize anchor addresses
+        ss >> anchors;
+    }
+    catch (const std::exception& e) {
+        return error("%s: Deserialize or I/O error - %s", __func__, e.what());
+    }
+
+    // Delete file after reading (one-shot, prevents stale anchors after crash)
+    boost::filesystem::remove(pathAnchor);
+
+    return true;
+}
+
 unsigned int ReceiveFloodSize() { return 1000*GetArg("-maxreceivebuffer", 5*1000); }
 unsigned int SendBufferSize() { return 1000*GetArg("-maxsendbuffer", 1*1000); }
 
@@ -2110,6 +2318,7 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     fClient = false; // set by version message
     fInbound = fInboundIn;
     fNetworkNode = false;
+    fFeeler = false;
     fSuccessfullyConnected = false;
     fDisconnect = false;
     nRefCount = 0;

--- a/src/net.h
+++ b/src/net.h
@@ -279,6 +279,7 @@ public:
     bool fClient;
     bool fInbound;
     bool fNetworkNode;
+    bool fFeeler;
     bool fSuccessfullyConnected;
     bool fDisconnect;
     // We use fRelayTxes for two purposes -
@@ -690,6 +691,17 @@ public:
     CAddrDB();
     bool Write(const CAddrMan& addr);
     bool Read(CAddrMan& addr);
+};
+
+/** Access to the anchor database (anchors.dat) */
+class CAnchorDB
+{
+private:
+    boost::filesystem::path pathAnchor;
+public:
+    CAnchorDB();
+    bool Write(const std::vector<CAddress>& anchors);
+    bool Read(std::vector<CAddress>& anchors);
 };
 
 #endif // BITCOIN_NET_H

--- a/src/net.h
+++ b/src/net.h
@@ -73,7 +73,7 @@ CNode* FindNode(const CSubNet& subNet);
 CNode* FindNode(const std::string& addrName);
 CNode* FindNode(const CService& ip);
 CNode* ConnectNode(CAddress addrConnect, const char *pszDest = NULL,  bool obfuScationMaster = false);
-bool OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGrant *grantOutbound = NULL, const char *strDest = NULL, bool fOneShot = false);
+bool OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGrant *grantOutbound = NULL, const char *strDest = NULL, bool fOneShot = false, bool fFeeler = false);
 unsigned short GetListenPort();
 bool BindListenPort(const CService &bindAddr, std::string& strError, bool fWhitelisted = false);
 void StartNode(boost::thread_group& threadGroup, CScheduler& scheduler);

--- a/src/net.h
+++ b/src/net.h
@@ -42,8 +42,10 @@ namespace boost {
 
 /** Time between pings automatically sent out for latency probing and keepalive (in seconds). */
 static const int PING_INTERVAL = 2 * 60;
-/** Time after which to disconnect, after waiting for a ping response (or inactivity). */
-static const int TIMEOUT_INTERVAL = 20 * 60;
+/** Time after which to disconnect, after waiting for a ping response (or inactivity).
+ *  3 missed ping cycles = dead connection. Reduced from Bitcoin's 20 min (designed for
+ *  10-min blocks) to match Flux's faster block times. */
+static const int TIMEOUT_INTERVAL = 3 * PING_INTERVAL;
 /** The maximum number of entries in an 'inv' protocol message */
 static const unsigned int MAX_INV_SZ = 50000;
 /** The maximum number of new addresses to accumulate before announcing. */

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -53,7 +53,6 @@ public:
     // Expose attempt count for testing smart failure counting
     int GetAttempts(const CNetAddr& addr)
     {
-        LOCK(cs);
         CAddrInfo* info = Find(addr);
         if (!info) return -1;
         return info->GetAttempts();

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -49,6 +49,15 @@ public:
     {
         CAddrMan::Delete(nId);
     }
+
+    // Expose attempt count for testing smart failure counting
+    int GetAttempts(const CNetAddr& addr)
+    {
+        LOCK(cs);
+        CAddrInfo* info = Find(addr);
+        if (!info) return -1;
+        return info->GetAttempts();
+    }
 };
 
 BOOST_FIXTURE_TEST_SUITE(addrman_tests, BasicTestingSetup)
@@ -519,4 +528,94 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     //  than 64 buckets.
     BOOST_CHECK(buckets.size() > 64);
 }
+BOOST_AUTO_TEST_CASE(addrman_smart_attempt_counting)
+{
+    CAddrManTest addrman;
+    addrman.MakeDeterministic();
+
+    CNetAddr source = CNetAddr("252.2.2.2");
+    CService addr1 = CService("250.1.1.1", 8333);
+    CService addr2 = CService("250.1.1.2", 8333);
+
+    addrman.Add(CAddress(addr1), source);
+    addrman.Add(CAddress(addr2), source);
+
+    // Multiple Attempt() calls without any Good() in between should only
+    // increment nAttempts once (smart failure counting, Bitcoin Core PR #11560)
+    addrman.Attempt(addr1);
+    addrman.Attempt(addr1);
+    addrman.Attempt(addr1);
+    BOOST_CHECK_EQUAL(addrman.GetAttempts(addr1), 1);
+
+    // Good() on a different address advances m_last_good epoch
+    addrman.Good(addr2);
+
+    // Now another Attempt() on addr1 should increment nAttempts to 2
+    addrman.Attempt(addr1);
+    BOOST_CHECK_EQUAL(addrman.GetAttempts(addr1), 2);
+
+    // But further attempts in the same epoch should not pile on
+    addrman.Attempt(addr1);
+    addrman.Attempt(addr1);
+    BOOST_CHECK_EQUAL(addrman.GetAttempts(addr1), 2);
+}
+
+BOOST_AUTO_TEST_CASE(addrman_good_resets_attempts)
+{
+    CAddrManTest addrman;
+    addrman.MakeDeterministic();
+
+    CNetAddr source = CNetAddr("252.2.2.2");
+    CService addr1 = CService("250.1.1.1", 8333);
+    CService addr2 = CService("250.1.1.2", 8333);
+
+    addrman.Add(CAddress(addr1), source);
+    addrman.Add(CAddress(addr2), source);
+
+    // Build up some attempts across multiple epochs
+    addrman.Attempt(addr1);
+    BOOST_CHECK_EQUAL(addrman.GetAttempts(addr1), 1);
+
+    addrman.Good(addr2); // advance epoch
+    addrman.Attempt(addr1);
+    BOOST_CHECK_EQUAL(addrman.GetAttempts(addr1), 2);
+
+    // Good() on addr1 itself should reset nAttempts to 0
+    addrman.Good(addr1);
+    BOOST_CHECK_EQUAL(addrman.GetAttempts(addr1), 0);
+}
+
+BOOST_AUTO_TEST_CASE(addrman_getchance_penalty_capped)
+{
+    CAddrManTest addrman;
+    addrman.MakeDeterministic();
+
+    CNetAddr source = CNetAddr("252.2.2.2");
+    CService addr1 = CService("250.1.1.1", 8333);
+
+    addrman.Add(CAddress(addr1), source);
+
+    // Simulate a network blip: multiple Attempt() calls with no Good()
+    // Smart failure counting means only 1 actual attempt is recorded
+    for (int i = 0; i < 10; i++)
+        addrman.Attempt(addr1);
+
+    // nAttempts should be 1, not 10
+    BOOST_CHECK_EQUAL(addrman.GetAttempts(addr1), 1);
+
+    // GetChance should reflect only 1 attempt's penalty, not 10
+    // With 1 attempt: penalty factor = pow(0.66, 1) = 0.66
+    // With 10 attempts (old behavior): penalty factor = pow(0.66, 8) ~= 0.036
+    CAddrInfo* info = addrman.Find(addr1);
+    BOOST_CHECK(info != NULL);
+    if (info) {
+        // Use a time far enough in the future so the 10-minute recency
+        // penalty doesn't apply
+        double chance = info->GetChance(GetAdjustedTime() + 3600);
+        // With 1 attempt, chance should be roughly 0.66
+        // With old behavior (10 attempts), chance would be ~0.036
+        BOOST_CHECK(chance > 0.5);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/net_reseed_tests.cpp
+++ b/src/test/net_reseed_tests.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2018-2022 The Flux Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include "net.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+#include <boost/filesystem.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(net_reseed_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(anchor_db_write_read)
+{
+    // Create test addresses
+    std::vector<CAddress> anchorsWrite;
+    CAddress addr1(CService("1.2.3.4", 16125));
+    addr1.nTime = 1000;
+    CAddress addr2(CService("5.6.7.8", 16125));
+    addr2.nTime = 2000;
+    anchorsWrite.push_back(addr1);
+    anchorsWrite.push_back(addr2);
+
+    // Write anchors to disk
+    CAnchorDB anchordb;
+    BOOST_CHECK(anchordb.Write(anchorsWrite));
+
+    // Read anchors back
+    std::vector<CAddress> anchorsRead;
+    BOOST_CHECK(anchordb.Read(anchorsRead));
+
+    // Verify round-trip
+    BOOST_CHECK_EQUAL(anchorsRead.size(), 2);
+    BOOST_CHECK(anchorsRead[0].ToStringIPPort() == addr1.ToStringIPPort());
+    BOOST_CHECK(anchorsRead[1].ToStringIPPort() == addr2.ToStringIPPort());
+
+    // File should be deleted after read (one-shot behavior)
+    boost::filesystem::path pathAnchor = GetDataDir() / "anchors.dat";
+    BOOST_CHECK(!boost::filesystem::exists(pathAnchor));
+}
+
+BOOST_AUTO_TEST_CASE(anchor_db_empty)
+{
+    // Ensure no anchors.dat exists
+    boost::filesystem::path pathAnchor = GetDataDir() / "anchors.dat";
+    boost::filesystem::remove(pathAnchor);
+
+    // Attempt to read non-existent anchors.dat
+    std::vector<CAddress> anchors;
+    CAnchorDB anchordb;
+    BOOST_CHECK(!anchordb.Read(anchors));
+
+    // Vector should be empty
+    BOOST_CHECK(anchors.empty());
+}
+
+BOOST_AUTO_TEST_CASE(anchor_db_max_limit)
+{
+    // Write 5 addresses
+    std::vector<CAddress> anchorsWrite;
+    for (int i = 1; i <= 5; i++) {
+        CAddress addr(CService("1.2.3." + boost::to_string(i), 16125));
+        addr.nTime = i * 1000;
+        anchorsWrite.push_back(addr);
+    }
+    CAnchorDB anchordb;
+    BOOST_CHECK(anchordb.Write(anchorsWrite));
+
+    // Read back - all 5 should be present in the file
+    std::vector<CAddress> anchorsRead;
+    BOOST_CHECK(anchordb.Read(anchorsRead));
+    BOOST_CHECK_EQUAL(anchorsRead.size(), 5);
+
+    // In practice, StartNode() caps to MAX_ANCHOR_CONNECTIONS (2),
+    // but CAnchorDB itself stores all addresses faithfully
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/net_timeout_tests.cpp
+++ b/src/test/net_timeout_tests.cpp
@@ -8,8 +8,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-// ---------- Timeout constant tests (no node infrastructure needed) ----------
-
 BOOST_FIXTURE_TEST_SUITE(net_timeout_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(timeout_interval_relationship)
@@ -28,12 +26,6 @@ BOOST_AUTO_TEST_CASE(timeout_interval_sane_for_flux)
     BOOST_CHECK(TIMEOUT_INTERVAL >= 3 * PING_INTERVAL);
     BOOST_CHECK(TIMEOUT_INTERVAL <= 600); // at most 10 minutes
 }
-
-BOOST_AUTO_TEST_SUITE_END()
-
-// ---------- Tests that need full node infrastructure (CNode creation) ----------
-
-BOOST_FIXTURE_TEST_SUITE(net_stale_tip_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(zombie_peer_unanswered_ping)
 {

--- a/src/test/net_timeout_tests.cpp
+++ b/src/test/net_timeout_tests.cpp
@@ -1,0 +1,132 @@
+// Copyright (c) 2018-2022 The Flux Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include "net.h"
+#include "test/test_bitcoin.h"
+#include "util.h"
+
+#include <boost/test/unit_test.hpp>
+
+// ---------- Timeout constant tests (no node infrastructure needed) ----------
+
+BOOST_FIXTURE_TEST_SUITE(net_timeout_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(timeout_interval_relationship)
+{
+    // TIMEOUT_INTERVAL must be exactly 3 ping cycles
+    BOOST_CHECK_EQUAL(TIMEOUT_INTERVAL, 3 * PING_INTERVAL);
+    // Verify absolute values: 2-minute pings, 6-minute timeout
+    BOOST_CHECK_EQUAL(PING_INTERVAL, 120);
+    BOOST_CHECK_EQUAL(TIMEOUT_INTERVAL, 360);
+}
+
+BOOST_AUTO_TEST_CASE(timeout_interval_sane_for_flux)
+{
+    // Timeout must be long enough to tolerate network jitter
+    // but short enough to catch dead connections before the watchdog (typically ~8 min)
+    BOOST_CHECK(TIMEOUT_INTERVAL >= 3 * PING_INTERVAL);
+    BOOST_CHECK(TIMEOUT_INTERVAL <= 600); // at most 10 minutes
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+// ---------- Tests that need full node infrastructure (CNode creation) ----------
+
+BOOST_FIXTURE_TEST_SUITE(net_stale_tip_tests, TestingSetup)
+
+BOOST_AUTO_TEST_CASE(zombie_peer_unanswered_ping)
+{
+    // A peer with a ping outstanding for > 30 seconds is a zombie
+    CAddress addr(CService("1.2.3.4", 16125));
+    CNode node(INVALID_SOCKET, addr, "", false); // outbound
+
+    // Simulate a ping sent 31 seconds ago with no pong
+    node.nPingNonceSent = 12345;
+    node.nPingUsecStart = GetTimeMicros() - 31 * 1000000LL;
+
+    // The zombie condition from CheckStaleTip (STALE_TIP_PING_TIMEOUT = 30s)
+    bool isZombie = (node.nPingNonceSent != 0 &&
+                     node.nPingUsecStart + 30 * 1000000LL < GetTimeMicros());
+    BOOST_CHECK(isZombie);
+}
+
+BOOST_AUTO_TEST_CASE(live_peer_answered_ping)
+{
+    // A peer with no outstanding ping (pong received) is not a zombie
+    CAddress addr(CService("1.2.3.5", 16125));
+    CNode node(INVALID_SOCKET, addr, "", false);
+
+    // nPingNonceSent == 0 means no outstanding ping (pong was received)
+    node.nPingNonceSent = 0;
+    node.nPingUsecStart = GetTimeMicros() - 60 * 1000000LL;
+
+    bool isZombie = (node.nPingNonceSent != 0 &&
+                     node.nPingUsecStart + 30 * 1000000LL < GetTimeMicros());
+    BOOST_CHECK(!isZombie);
+}
+
+BOOST_AUTO_TEST_CASE(recent_ping_not_zombie)
+{
+    // A peer with a recently-sent ping (within 30s) should not be killed yet
+    CAddress addr(CService("1.2.3.6", 16125));
+    CNode node(INVALID_SOCKET, addr, "", false);
+
+    // Ping sent 5 seconds ago, no pong yet — give it time
+    node.nPingNonceSent = 67890;
+    node.nPingUsecStart = GetTimeMicros() - 5 * 1000000LL;
+
+    bool isZombie = (node.nPingNonceSent != 0 &&
+                     node.nPingUsecStart + 30 * 1000000LL < GetTimeMicros());
+    BOOST_CHECK(!isZombie);
+}
+
+BOOST_AUTO_TEST_CASE(inbound_peer_not_probed)
+{
+    // Inbound peers should be skipped by the stale tip probe
+    CAddress addr(CService("1.2.3.7", 16125));
+    CNode node(INVALID_SOCKET, addr, "", true); // inbound
+
+    BOOST_CHECK(node.fInbound);
+    // CheckStaleTip skips: fInbound || fOneShot || fDisconnect
+    bool shouldProbe = !node.fInbound && !node.fOneShot && !node.fDisconnect;
+    BOOST_CHECK(!shouldProbe);
+}
+
+BOOST_AUTO_TEST_CASE(outbound_peer_probed)
+{
+    // Outbound peers should be probed when tip is stale
+    CAddress addr(CService("1.2.3.8", 16125));
+    CNode node(INVALID_SOCKET, addr, "", false); // outbound
+
+    BOOST_CHECK(!node.fInbound);
+    BOOST_CHECK(!node.fOneShot);
+    BOOST_CHECK(!node.fDisconnect);
+    bool shouldProbe = !node.fInbound && !node.fOneShot && !node.fDisconnect;
+    BOOST_CHECK(shouldProbe);
+
+    // Queuing a ping sets fPingQueued
+    node.fPingQueued = true;
+    BOOST_CHECK(node.fPingQueued);
+}
+
+BOOST_AUTO_TEST_CASE(inactivity_timeout_boundary)
+{
+    CAddress addr(CService("1.2.3.9", 16125));
+    CNode node(INVALID_SOCKET, addr, "", false);
+    node.nVersion = 170002; // > BIP0031_VERSION
+
+    // 5 minutes of silence — should NOT trigger (threshold is 6 min)
+    node.nLastRecv = GetTime() - 300;
+    BOOST_CHECK(GetTime() - node.nLastRecv <= TIMEOUT_INTERVAL);
+
+    // 7 minutes of silence — SHOULD trigger
+    node.nLastRecv = GetTime() - 420;
+    BOOST_CHECK(GetTime() - node.nLastRecv > TIMEOUT_INTERVAL);
+
+    // Exactly at the boundary (6 min) — should NOT trigger (uses >)
+    node.nLastRecv = GetTime() - TIMEOUT_INTERVAL;
+    BOOST_CHECK(!(GetTime() - node.nLastRecv > TIMEOUT_INTERVAL));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
> **Note:** This branch uses `BOOST_FOREACH` and Boost threading to match the current `master` codebase. If [#272 (Remove boost dependencies, upgrade to C++20)](https://github.com/RunOnFlux/fluxd/pull/272) merges first, this can be rebased on top with a straightforward find-and-replace (`BOOST_FOREACH` → range-for, `boost::thread` → `std::thread`, etc.).

## Problem

A brief network disruption caused all p2p peers to silently disconnect on several production Flux nodes. The affected nodes stalled for ~7 minutes until `flux-watchdog` force-restarted `fluxd`. Investigation of production logs on an affected node revealed:

- **Zero disconnect messages** in `debug.log` during the entire stall
- TCP connections remained `ESTABLISHED` at the kernel level — classic **zombie connections**
- Only PON difficulty recalculations appeared in the log; no networking activity whatsoever
- `flux-watchdog` eventually killed `fluxd` after detecting the node was behind

### Root cause

fluxd's networking layer is inherited from the Bitcoin Core ~v0.12 era (via the Zcash → ZelCash → Flux fork chain). This predates many of the resilience features Bitcoin Core added in v0.13–v0.21, leaving fluxd unable to recover from network disruptions:

1. **20-minute inactivity timeout** (`TIMEOUT_INTERVAL = 20 * 60`) — Designed for Bitcoin's 10-minute blocks, zombie connections can persist for up to 20 minutes before being cleaned up. For Flux's block interval (2 minutes pre-PON, ~30 seconds post-PON), this is catastrophically slow — the watchdog kills `fluxd` long before the timeout fires.

2. **No zombie detection** — There is no mechanism to actively probe peers when the chain tip stops advancing. The node passively waits for the 20-minute timeout while blocks pile up on the network.

3. **Addrman penalty spiral** — After a network blip, every reconnection attempt increments `nAttempts` on each address. The selection probability decays as `pow(0.66, nAttempts)`, so after just 5 failed attempts an address has only a 13% chance of being selected. With all ~1000 addresses penalised simultaneously, the node struggles to find any peer to connect to.

4. **No address table maintenance** — Without feeler connections, the address table fills with stale entries over time, reducing the pool of known-good peers available during recovery.

### Network failure scenarios

These are the real-world scenarios that can cause zombie connections:

| Scenario | What happens | Old behavior | New behavior |
|----------|-------------|--------------|-------------|
| **NAT/middlebox state loss** | ISP router reboots, drops NAT mappings. TCP connections look alive locally but remote packets are blackholed. | 20-min timeout, watchdog kills first | 3.5 min: zombie probe → disconnect → reconnect from addrman |
| **Asymmetric routing failure** | Upstream path works, downstream doesn't. `send()` succeeds but no data arrives. | Same — silent death | Same 3.5 min recovery |
| **UFW/iptables flap** | FluxOS port capability test (`ufw allow/delete`) briefly disrupts conntrack. | Connections silently die | Zombie detection catches it |
| **Brief ISP outage** | 30-60 second connectivity loss. Long enough to break TCP but short enough that `ESTABLISHED` state persists. | All peers penalised in addrman, slow reconnection | Smart failure counting prevents penalty spiral, feelers keep address table fresh |
| **DDoS / traffic spike** | Saturated uplink drops p2p packets for minutes. | Indistinguishable from zombie scenario | Same recovery path |

## Solution

This PR ports the most impactful network resilience features from modern Bitcoin Core (v0.13–v0.21), adapted for Flux's architecture (globals-based networking, no `CConnman`, C++11).

### Feature comparison

| Feature | Bitcoin Core | This PR | Notes |
|---------|-------------|---------|-------|
| **Stale tip detection** | `TipMayBeStale()` (v0.15.1, PR [#11560](https://github.com/bitcoin/bitcoin/pull/11560)) — sets flag after `3 × nPowTargetSpacing` with no new block | `CheckStaleTip()` — probes all outbound peers with pings after 180s of no new block | Bitcoin's approach adds an extra outbound peer; we actively probe existing peers because the problem is zombie connections, not missing peers |
| **Zombie peer disconnection** | `ConsiderEviction()` (v0.16) — per-peer `getheaders` challenge with 20-min `CHAIN_SYNC_TIMEOUT` | Ping-probe with 30s timeout — unanswered ping = zombie = disconnect | Faster detection (30s vs 20 min). Bitcoin's `getheaders` approach is overkill for zombie detection |
| **Inactivity timeout** | `TIMEOUT_INTERVAL = 20 * 60` (20 min) — designed for 10-min Bitcoin blocks | `TIMEOUT_INTERVAL = 3 × PING_INTERVAL` (6 min) — 3 missed ping cycles = dead | See "Why 20 minutes was wrong for Flux" below |
| **Smart failure counting** | [`6182d10`](https://github.com/bitcoin/bitcoin/commit/6182d10503) (v0.13) — epoch-based attempt counting | Same approach — `nLastCountAttempt` + `m_last_good` epoch | Prevents `nAttempts` from spiraling during simultaneous failures. Only counts one failure per address per "failure epoch" |
| **Feeler connections** | PR [#8282](https://github.com/bitcoin/bitcoin/pull/8282) (v0.13) — periodic connections to untried addresses | Same — every 120s, connect to an untried address from addrman's "new" table, disconnect after version handshake | Keeps the address table fresh with recently-verified peers |
| **Anchor connections** | PR [#17428](https://github.com/bitcoin/bitcoin/pull/17428) (v0.21) — save 2 best peers to `anchors.dat` on shutdown | Same — `CAnchorDB` writes/reads `anchors.dat`, tried first on startup | Fast reconnection after restart (including watchdog-triggered). One-shot file deleted after read |
| **Extra outbound peer** | Connects an additional outbound peer when tip is stale | Not implemented | Bitcoin's approach is designed for slow tip advancement. For the all-zombies scenario, adding one more zombie doesn't help — we need to detect and kill the zombies instead |

### Why 20 minutes was wrong for Flux

Bitcoin Core's `TIMEOUT_INTERVAL` of 20 minutes (1200 seconds) makes sense in Bitcoin's context:
- **10-minute block interval** — it's normal to not receive a block for 20+ minutes
- **No watchdog** — bitcoind manages its own lifecycle
- **Conservative design** — false positives (disconnecting a slow but alive peer) are worse than slow recovery

For Flux, this timeout is catastrophic:
- **Block interval is 2 minutes pre-PON, ~30 seconds post-PON** — 20 minutes of silence is wildly disproportionate
- **flux-watchdog** kills fluxd after ~6-8 minutes of being behind — the timeout never fires
- **`PING_INTERVAL` is 2 minutes** — a peer that hasn't responded to 3 consecutive pings (6 min) is dead

The new `TIMEOUT_INTERVAL = 3 × PING_INTERVAL` (360s / 6 min) means:
- A peer must miss 3 consecutive ping cycles to be timed out
- Still generous enough to tolerate transient network jitter
- Actually fires before the watchdog kills the process
- Backed by the stale tip zombie detector which catches problems even faster (3.5 min)

## Live network testing

Used `iptables -j DROP` on port 16125 on a live node to simulate zombie connections (TCP stays `ESTABLISHED`, no data flows) — identical to the production failure scenario:

```
+0:00  — iptables DROP applied (simulating zombie connections)
+3:03  — Stale tip (height 2361275, 180s old): probing 16 outbound peers
+3:33  — Stale tip: 16 peers ping unanswered for 30s, disconnecting
+3:33  — Stale tip: disconnected 16/16 zombie outbound peers
+3:36  — (iptables removed) New peers connected from addrman, 7 blocks synced in <1 second
+4:03  — Fully caught up at tip
```

**Result:** 3.5 minutes from network loss to full recovery. No watchdog intervention needed.

## Changes

### Files modified

| File | Lines | Description |
|------|-------|-------------|
| `src/net.cpp` | +257/-6 | Stale tip detection, feeler connections, anchor connections |
| `src/net.h` | +20/-2 | `fFeeler` flag, `CAnchorDB` class, `TIMEOUT_INTERVAL` reduction |
| `src/addrman.h` | +11 | `nLastCountAttempt`, `m_last_good` epoch fields |
| `src/addrman.cpp` | +11/-1 | Smart failure counting in `Attempt_()` and `Good_()` |
| `src/main.cpp` | +7 | Feeler disconnect after version handshake |
| `src/test/addrman_tests.cpp` | +98 | Smart failure counting tests |
| `src/test/net_reseed_tests.cpp` | +78 | Anchor DB persistence tests |
| `src/test/net_timeout_tests.cpp` | +124 | Timeout constants, zombie detection, inactivity boundary tests |
| `src/Makefile.test.include` | +2 | Register new test files |

### Commits

1. `adef6f6a5` — Port core resilience fixes (smart addrman, feelers, anchors, tests)
2. `8e2fa137b` — Add debug logging for feelers, failure suppression, and recovery
3. `d9c46c384` — Pass fFeeler through OpenNetworkConnection to eliminate race
4. `555397638` — Fix test helper lock issue (cs is private to CAddrMan)
5. `fb095ce9f` — Use epoch counter instead of timestamp for failure counting
6. `90197ca9d` — Add stale tip zombie detection and reduce inactivity timeout
7. `0eb522936` — Add timeout and zombie detection unit tests
8. `c9dcccc5d` — Move CheckStaleTip to ThreadMessageHandler (fix semaphore deadlock)
9. `60f43b3b3` — Use BasicTestingSetup for timeout tests (avoid 9s fixture overhead)
10. `a58149ed9` — Remove DNSReseedIfNeeded (redundant with other resilience features)

## Test plan

- [x] Unit tests pass (`make check`)
  - `addrman_tests` — smart failure counting (3 new tests)
  - `net_reseed_tests` — anchor DB persistence (3 tests)
  - `net_timeout_tests` — timeout constants, zombie detection, inactivity boundaries (8 tests)
- [x] Live zombie test — `iptables DROP` simulating zombie connections, full recovery in 3.5 min
- [x] No serialization changes to addrman (no database migration needed — new fields are memory-only)
- [ ] Extended soak test on production node

🤖 Generated with [Claude Code](https://claude.com/claude-code)