### PR TITLE
fix: null-terminate readlink buffer in GetSelfPath

### DIFF
--- a/src/fluxnode/benchmarks.cpp
+++ b/src/fluxnode/benchmarks.cpp
@@ -45,11 +45,12 @@ std::string GetSelfPath()
 {
     #if defined(__linux)
         char result[ PATH_MAX ];
-        ssize_t count = readlink( "/proc/self/exe", result, PATH_MAX );
+        ssize_t count = readlink( "/proc/self/exe", result, PATH_MAX - 1 );
 
         const char *path;
 
         if (count != -1) {
+            result[count] = '\0';
             path = dirname(result);
             return std::string(path);
         }


### PR DESCRIPTION
## Summary

- Null-terminate the buffer returned by `readlink()` before passing it to `dirname()` in `GetSelfPath()`

## Problem

Observed fluxd failing to start intermittently with:

```
2026-03-13 11:27:52 Path: /usr/local/bin/fluxd
2026-03-13 11:27:52 Error: Failed to find benchmark application
2026-03-13 11:27:52 Shutdown: In progress...
```

After systemd restarted the service, it worked fine:

```
2026-03-13 11:28:37 Path: /usr/local/bin
2026-03-13 11:28:37 Found fluxbenchd in /usr/local/bin
```

On the failed start, `GetSelfPath()` returned `/usr/local/bin/fluxd` (full binary path) instead of `/usr/local/bin` (directory only). This caused `FindBenchmarkPath("fluxbenchd", "/usr/local/bin/fluxd")` to look for `/usr/local/bin/fluxd/fluxbenchd` which doesn't exist.

## Root cause

`readlink()` does not append a null byte to the buffer. `GetSelfPath()` passes the un-terminated buffer directly to `dirname()`, which reads past the valid bytes into whatever garbage is on the stack. If that garbage happens to contain a `/` character, `dirname()` finds it and returns the wrong directory. Whether the stack contains a `/` depends on prior call history, ASLR, environment size, etc. — hence the intermittent nature.

## Test plan

Built a test binary that reproduces the issue by simulating dirty stack memory:

```
broken raw: /usr/local/bin/fluxdaaaaa/aaaa
broken dirname: /usr/local/bin/fluxdaaaaa    <-- wrong

fixed  raw: /usr/local/bin/fluxd
fixed  dirname: /usr/local/bin               <-- correct
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)