### PR TITLE
fix: detect corrupt block index entries during load

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -509,8 +509,18 @@ bool CBlockTreeDB::LoadBlockIndexGuts(boost::function<CBlockIndex*(const uint256
         if (pcursor->GetKey(key) && key.first == DB_BLOCK_INDEX) {
             CDiskBlockIndex diskindex;
             if (pcursor->GetValue(diskindex)) {
-                // Construct block index object
-                CBlockIndex* pindexNew = insertBlockIndex(diskindex.GetBlockHash());
+                // Verify computed hash matches LevelDB key to detect on-disk
+                // corruption (e.g. bit flips). Without this, a corrupt entry
+                // gets inserted under a wrong hash, leaving stub entries with
+                // NULL pprev that crash in BuildSkip/GetAncestor.
+                uint256 computedHash = diskindex.GetBlockHash();
+                if (computedHash != key.second)
+                    return error("LoadBlockIndex(): corrupt block index entry at height %d: "
+                        "computed hash %s != stored key %s",
+                        diskindex.nHeight, computedHash.ToString(), key.second.ToString());
+
+                // Construct block index object using the stored key hash
+                CBlockIndex* pindexNew = insertBlockIndex(key.second);
                 pindexNew->pprev          = insertBlockIndex(diskindex.hashPrev);
                 pindexNew->nHeight        = diskindex.nHeight;
                 pindexNew->nFile          = diskindex.nFile;


### PR DESCRIPTION
## Summary

- A single bit flip in a block index LevelDB value causes `GetBlockHash()` to compute a wrong hash, inserting the entry under an incorrect key in `mapBlockIndex`. Child blocks referencing the correct hash via `hashPrev` create a stub with `pprev=NULL`. `BuildSkip` then walks into the stub, hitting `assert(pindexWalk->pprev)` at `chain.cpp:94`, which calls `abort()` and **produces a core dump (SIGABRT)**. Systemd restarts fluxd, which hits the same corruption and crashes again — resulting in an **infinite core dump loop** (300+ restarts observed on a production node).
- The existing consistency check (`header.GetHash() != GetBlockHash()`) misses this because both sides derive from the same corrupt data — it compares the computed hash against itself, not the stored LevelDB key.
- Add a check comparing the computed hash against `key.second` (the LevelDB key), which is the authoritative stored hash. Exit cleanly with a descriptive error instead of core dumping.

## Test plan

- [x] Tested on a node with a known single-bit-flip corruption at height 2,225,820
- [x] **Before fix**: infinite core dump loop — `fluxd: chain.cpp:94: CBlockIndex* CBlockIndex::GetAncestor(int): Assertion 'pindexWalk->pprev' failed.` (SIGABRT, exit code 134, 300+ restarts)
- [x] **After fix**: single clean exit (code 1) with `ERROR: LoadBlockIndex(): corrupt block index entry at height 2225820: computed hash ... != stored key ...`
- [x] Tested on a healthy node: loads normally, no false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)