### PR TITLE
Perf/ibd speedups

### DIFF
--- a/src/fluxnode/fluxnode.cpp
+++ b/src/fluxnode/fluxnode.cpp
@@ -1809,6 +1809,8 @@ int GetNumberOfTiers()
 
 void FluxnodeCache::LogDebugData(const int& nHeight, const uint256& blockhash, bool fFromDisconnect)
 {
+    if (!LogAcceptCategory("fluxnode")) return;
+
     LOCK(cs);
     std::string printme = "{ \n";
     for (const auto &printitem: mapStartTxTracker) {
@@ -1823,10 +1825,10 @@ void FluxnodeCache::LogDebugData(const int& nHeight, const uint256& blockhash, b
     printme3 = printme3 + "}";
 
     if (fFromDisconnect) {
-        LogPrintf("Disconnecting - printing after block=%d, hash=%s\n, mapStart=%s\n\n, mapStartTxDOSTracker=%s\n\n",
+        LogPrint("fluxnode", "Disconnecting - printing after block=%d, hash=%s\n, mapStart=%s\n\n, mapStartTxDOSTracker=%s\n\n",
                   nHeight, blockhash.GetHex(), printme, printme3);
     } else {
-        LogPrintf("printing after block=%d, hash=%s\n, mapStart=%s\n\n, mapStartTxDOSTracker=%s\n\n",
+        LogPrint("fluxnode", "printing after block=%d, hash=%s\n, mapStart=%s\n\n, mapStartTxDOSTracker=%s\n\n",
                   nHeight, blockhash.GetHex(), printme, printme3);
     }
 

--- a/src/fluxnode/fluxnode.cpp
+++ b/src/fluxnode/fluxnode.cpp
@@ -479,6 +479,9 @@ bool FluxnodeCache::CheckNewStartTx(const COutPoint& out, int nHeight, bool fFro
 void FluxnodeCache::CheckForExpiredStartTx(const int& p_nHeight)
 {
     LOCK2(cs, g_fluxnodeCache.cs);
+    if (g_fluxnodeCache.mapStartTxTracker.empty()) {
+        return;
+    }
     int removalHeight = p_nHeight - FLUXNODE_START_TX_EXPIRATION_HEIGHT;
 
     if (IsPONActive(p_nHeight)) {
@@ -507,6 +510,9 @@ void FluxnodeCache::CheckForExpiredStartTx(const int& p_nHeight)
 void FluxnodeCache::CheckForUndoExpiredStartTx(const int& p_nHeight)
 {
     LOCK2(cs, g_fluxnodeCache.cs);
+    if (g_fluxnodeCache.mapStartTxDOSTracker.empty()) {
+        return;
+    }
     int removalHeight = p_nHeight - FLUXNODE_START_TX_EXPIRATION_HEIGHT;
 
     if (IsPONActive(p_nHeight)) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1474,24 +1474,24 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         }
     }
 
-    // cache size calculations
+    // https://github.com/bitpay/bitcoin/commit/c91d78b578a8700a45be936cb5bb0931df8f4b87#diff-c865a8939105e6350a50af02766291b7R1233
+    if (GetBoolArg("-insightexplorer", false) && !GetBoolArg("-txindex", false)) {
+        return InitError(_("-insightexplorer requires -txindex."));
+    }
+
+    // cache size calculations (matches Bitcoin Core's allocation so most of
+    // -dbcache goes to the in-memory UTXO set during IBD instead of the
+    // block tree DB)
+    const bool fHaveBlockTreeIndexes = GetBoolArg("-txindex", false) ||
+                                        GetBoolArg("-insightexplorer", false);
     int64_t nTotalCache = (GetArg("-dbcache", nDefaultDbCache) << 20);
     nTotalCache = std::max(nTotalCache, nMinDbCache << 20); // total cache cannot be less than nMinDbCache
-    nTotalCache = std::min(nTotalCache, nMaxDbCache << 20); // total cache cannot be greated than nMaxDbcache
-    int64_t nBlockTreeDBCache = nTotalCache / 8;
-    if (nBlockTreeDBCache > (1 << 21) && !GetBoolArg("-txindex", false))
-        nBlockTreeDBCache = (1 << 21); // block tree db cache shouldn't be larger than 2 MiB
-
-    // https://github.com/bitpay/bitcoin/commit/c91d78b578a8700a45be936cb5bb0931df8f4b87#diff-c865a8939105e6350a50af02766291b7R1233
-    if (GetBoolArg("-insightexplorer", false)) {
-        if (!GetBoolArg("-txindex", false)) {
-            return InitError(_("-insightexplorer requires -txindex."));
-        }
-        // increase cache if additional indices are needed
-        nBlockTreeDBCache = nTotalCache * 3 / 4;
-    }
+    nTotalCache = std::min(nTotalCache, nMaxDbCache << 20); // total cache cannot be greater than nMaxDbcache
+    int64_t nBlockTreeDBCache = std::min(nTotalCache / 8,
+        (fHaveBlockTreeIndexes ? nMaxBlockDBAndTxIndexCache : nMaxBlockDBCache) << 20);
     nTotalCache -= nBlockTreeDBCache;
     int64_t nCoinDBCache = std::min(nTotalCache / 2, (nTotalCache / 4) + (1 << 23)); // use 25%-50% of the remainder for disk cache
+    nCoinDBCache = std::min(nCoinDBCache, nMaxCoinsDBCache << 20);
     nTotalCache -= nCoinDBCache;
     nCoinCacheUsage = nTotalCache; // the rest goes to in-memory cache
     LogPrintf("Cache configuration:\n");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1224,8 +1224,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 #ifndef WIN32
     CreatePidFile(GetPidFile(), getpid());
 #endif
-    // Shrink debug.log on startup if it's too large (configurable, default 500MB) - keeps last 50MB
-    if (GetBoolArg("-shrinkdebugfile", !fDebug))
+    // Shrink debug.log on startup if it's too large (configurable, default
+    // 500 MB, capped at 10 GB). Runs regardless of -debug so the file can't
+    // grow without bound when debug logging is enabled.
+    if (GetBoolArg("-shrinkdebugfile", true))
         ShrinkDebugFile();
 
     if (fPrintToDebugLog)
@@ -2068,6 +2070,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     CScheduler::Function f = boost::bind(&PartitionCheck, &IsInitialBlockDownload,
                                          boost::ref(cs_main), boost::cref(pindexBestHeader), nPowTargetSpacing);
     scheduler.scheduleEvery(f, nPowTargetSpacing);
+
+    // Periodically cap debug.log size. Runs even when -debug is enabled so a
+    // firehose of debug output can't fill the disk. Interval: 5 minutes.
+    scheduler.scheduleEvery(&ShrinkDebugFile, 300);
 
 #ifdef ENABLE_MINING
     // Generate coins in the background

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -634,11 +634,35 @@ void FinalizeNode(NodeId nodeid) {
     // Remove from high-bandwidth compact block peer list
     lNodesAnnouncingHeaderAndIDs.remove(nodeid);
 
-    // Clean up any partial compact blocks from this peer
-    for (auto it = mapPartialBlocks.begin(); it != mapPartialBlocks.end(); ) {
-        // Note: PartiallyDownloadedBlock doesn't track which peer it came from in current implementation
-        // This is something we should improve in future iterations
-        ++it;
+    // Clean up any compact-block in-flight state tied to this peer.
+    // listCompactBlocksInFlight is the source of truth; mapCompactBlocksInFlight
+    // is the hash->iterator index. Collect affected block hashes so we can drop
+    // their partial-block entries once no other peer is still working on them.
+    std::set<uint256> affectedHashes;
+    for (auto it = listCompactBlocksInFlight.begin(); it != listCompactBlocksInFlight.end(); ) {
+        if (it->nodeid == nodeid) {
+            affectedHashes.insert(it->hash);
+            auto mapIt = mapCompactBlocksInFlight.find(it->hash);
+            if (mapIt != mapCompactBlocksInFlight.end() && mapIt->second.first == nodeid) {
+                mapCompactBlocksInFlight.erase(mapIt);
+            }
+            it = listCompactBlocksInFlight.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    for (const uint256& hash : affectedHashes) {
+        bool stillInFlight = false;
+        for (const auto& marker : listCompactBlocksInFlight) {
+            if (marker.hash == hash) {
+                stillInFlight = true;
+                break;
+            }
+        }
+        if (!stillInFlight) {
+            mapPartialBlocks.erase(hash);
+            mapPartialBlocksTime.erase(hash);
+        }
     }
 
     mapNodeState.erase(nodeid);
@@ -6938,10 +6962,8 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                     else if (inv.type == MSG_CMPCT_BLOCK)
                     {
                         // BIP 152 low-bandwidth mode: peer-initiated compact block request.
-                        // If the block is too old (more than MAX_CMPCTBLOCK_DEPTH deep),
-                        // fall back to sending the full block because the peer is unlikely
-                        // to have the mempool state needed to reconstruct it.
-                        static const int MAX_CMPCTBLOCK_DEPTH = 5;
+                        // For older blocks fall back to sending the full block because the
+                        // peer is unlikely to have the mempool state needed to reconstruct.
                         if (mi->second->nHeight >= chainActive.Height() - MAX_CMPCTBLOCK_DEPTH) {
                             CBlockHeaderAndShortTxIDs cmpctblock(block, false);
                             pfrom->PushMessage("cmpctblock", cmpctblock);
@@ -7996,7 +8018,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         // DoS protection: only accept compact blocks that are close to the tip
         // This prevents attackers from wasting our CPU/bandwidth with old blocks
-        if (pindex->nHeight < chainActive.Height() - MAX_BLOCKTXN_DEPTH) {
+        if (pindex->nHeight < chainActive.Height() - MAX_CMPCTBLOCK_DEPTH) {
             LogPrint("cmpctblock", "Ignoring compact block from peer %d at height %d (tip is %d)\n",
                      pfrom->id, pindex->nHeight, chainActive.Height());
             return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6876,6 +6876,7 @@ bool static AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
                    pcoinsTip->HaveCoins(inv.hash);
         }
     case MSG_BLOCK:
+    case MSG_CMPCT_BLOCK:
         return mapBlockIndex.count(inv.hash);
     }
     // Don't know what it is, just say we already got one
@@ -6902,7 +6903,7 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
             boost::this_thread::interruption_point();
             it++;
 
-            if (inv.type == MSG_BLOCK || inv.type == MSG_FILTERED_BLOCK)
+            if (inv.type == MSG_BLOCK || inv.type == MSG_FILTERED_BLOCK || inv.type == MSG_CMPCT_BLOCK)
             {
                 bool send = false;
                 BlockMap::iterator mi = mapBlockIndex.find(inv.hash);
@@ -6934,6 +6935,20 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                         assert(!"cannot load block from disk");
                     if (inv.type == MSG_BLOCK)
                         pfrom->PushMessage("block", block);
+                    else if (inv.type == MSG_CMPCT_BLOCK)
+                    {
+                        // BIP 152 low-bandwidth mode: peer-initiated compact block request.
+                        // If the block is too old (more than MAX_CMPCTBLOCK_DEPTH deep),
+                        // fall back to sending the full block because the peer is unlikely
+                        // to have the mempool state needed to reconstruct it.
+                        static const int MAX_CMPCTBLOCK_DEPTH = 5;
+                        if (mi->second->nHeight >= chainActive.Height() - MAX_CMPCTBLOCK_DEPTH) {
+                            CBlockHeaderAndShortTxIDs cmpctblock(block, false);
+                            pfrom->PushMessage("cmpctblock", cmpctblock);
+                        } else {
+                            pfrom->PushMessage("block", block);
+                        }
+                    }
                     else // MSG_FILTERED_BLOCK)
                     {
                         LOCK(pfrom->cs_filter);

--- a/src/main.h
+++ b/src/main.h
@@ -125,8 +125,15 @@ static const int64_t DEFAULT_MAX_TIP_AGE = 4 * 60 * 60;
 static const int MAX_UNCONNECTING_HEADERS = 10;
 /** Maximum number of compact blocks in flight per block */
 static const unsigned int MAX_CMPCTBLOCKS_INFLIGHT_PER_BLOCK = 3;
-/** Maximum depth for responding to GETBLOCKTXN requests */
-static const int MAX_BLOCKTXN_DEPTH = 10;
+/** Maximum depth at which we accept inbound cmpctblock messages or serve
+ *  outbound ones in response to MSG_CMPCT_BLOCK getdata requests.
+ *  Older blocks fall back to a full block because the requester's mempool
+ *  is unlikely to have the transactions needed to reconstruct.
+ *
+ *  Sized to roughly match Bitcoin Core's ~50-minute wall-clock window.
+ *  Bitcoin Core uses 5 at 10-minute block times; fluxd runs 30-second
+ *  PON blocks, so 100 blocks ≈ 50 minutes. */
+static const int MAX_CMPCTBLOCK_DEPTH = 100;
 /** Size of extra transaction pool for compact block reconstruction */
 static const unsigned int EXTRA_TXNS_FOR_COMPACT_BLOCKS = 100;
 

--- a/src/pon/pon.cpp
+++ b/src/pon/pon.cpp
@@ -137,7 +137,7 @@ unsigned int GetNextPONWorkRequired(const CBlockIndex* pindexLast)
     // Target timespan = (window - 1) * target spacing (because we're measuring intervals)
     int64_t targetTimespan = (lookbackWindow - 1) * params.nPonTargetSpacing;
 
-    LogPrintf("PON: Adjustment at height %d: first=%d, last=%d, actualTimespan=%d, targetTimespan=%d\n",
+    LogPrint("pon", "PON: Adjustment at height %d: first=%d, last=%d, actualTimespan=%d, targetTimespan=%d\n",
               nextHeight, pindexFirst->nHeight, pindexLast->nHeight, actualTimespan, targetTimespan);
 
     // Sanity check
@@ -187,7 +187,7 @@ unsigned int GetNextPONWorkRequired(const CBlockIndex* pindexLast)
         newTarget = ponLimit;  // Use easiest difficulty as failsafe
     }
 
-    LogPrintf("PON difficulty adjustment: height=%d, actualTimespan=%d, targetTimespan=%d, before=%08x, after=%08x\n",
+    LogPrint("pon", "PON difficulty adjustment: height=%d, actualTimespan=%d, targetTimespan=%d, before=%08x, after=%08x\n",
               pindexLast->nHeight + 1, actualTimespan, targetTimespan,
               pindexLast->nBits, newTarget.GetCompact());
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -25,7 +25,8 @@ static const char* ppszTypeName[] =
     "zn quorum",
     "zn announce",
     "zn ping",
-    "dstx"
+    "dstx",
+    "cmpct block"
 };
 
 CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn)
@@ -139,7 +140,9 @@ bool CInv::IsKnownType() const
 
 bool CInv::IsFluxnodeType() const
 {
-    return (type >= 4);
+    // Types 4-10 are Flux-network-specific invs (spork, zn winner, etc).
+    // MSG_CMPCT_BLOCK (type 11) is not a fluxnode type.
+    return (type >= 4 && type <= 10);
 }
 
 const char* CInv::GetCommand() const

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -160,7 +160,13 @@ enum {
     MSG_BLOCK,
     // Nodes may always request a MSG_FILTERED_BLOCK in a getdata, however,
     // MSG_FILTERED_BLOCK should not appear in any invs except as a part of getdata.
-    MSG_FILTERED_BLOCK
+    MSG_FILTERED_BLOCK,
+    // Reserved inv types 4-10 are used for fluxnode-specific invs (see
+    // ppszTypeName in protocol.cpp).
+    // BIP 152 low-bandwidth mode: peer-initiated compact block request.
+    // Diverges from Bitcoin Core's MSG_CMPCT_BLOCK=4 because type 4 is
+    // already used as "spork" on the Flux network.
+    MSG_CMPCT_BLOCK = 11,
 };
 
 #endif // BITCOIN_PROTOCOL_H

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -46,6 +46,13 @@ static const int64_t nDefaultDbCache = 450;
 static const int64_t nMaxDbCache = sizeof(void*) > 4 ? 16384 : 1024;
 //! min. -dbcache in (MiB)
 static const int64_t nMinDbCache = 4;
+//! Max memory allocated to block tree DB specific cache (MiB)
+static const int64_t nMaxBlockDBCache = 2;
+//! Max memory allocated to block tree DB specific cache, if -txindex or
+//  insight-explorer indexes are enabled (MiB)
+static const int64_t nMaxBlockDBAndTxIndexCache = 1024;
+//! Max memory allocated to coin DB specific cache (MiB)
+static const int64_t nMaxCoinsDBCache = 8;
 
 struct CDiskTxPos : public CDiskBlockPos
 {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -892,37 +892,54 @@ void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length) {
 
 void ShrinkDebugFile()
 {
-    // Scroll debug.log if it's getting too big
+    // Scroll debug.log if it's getting too big.
+    // Safe to call at any time: reads the tail into memory, writes to a temp
+    // file, and atomically renames over debug.log. Any concurrent LogPrintStr
+    // writes land on the unlinked inode; LogPrintStr reopens on next call
+    // when fReopenDebugLog is set.
     boost::filesystem::path pathLog = GetDataDir() / "debug.log";
-    FILE* file = fopen(pathLog.string().c_str(), "r");
 
-    // Get configurable size threshold (default 500MB, min 10MB, max 10GB)
-    int64_t nMaxLogSizeMB = GetArg("-maxdebugfilesize", 500); // Default 500MB
-    if (nMaxLogSizeMB < 10) nMaxLogSizeMB = 10;       // Minimum 10MB
-    if (nMaxLogSizeMB > 2048) nMaxLogSizeMB = 2048; // Maximum 2GB
+    // Get configurable size threshold. Default 500 MB, min 10 MB. Upper cap
+    // depends on whether debug logging is active: 10 GiB with -debug on so a
+    // long debug session has room to breathe, 2 GiB otherwise.
+    int64_t nMaxLogSizeMB = GetArg("-maxdebugfilesize", 500);
+    const int64_t nUpperCapMB = fDebug ? 10240 : 2048;
+    if (nMaxLogSizeMB < 10) nMaxLogSizeMB = 10;
+    if (nMaxLogSizeMB > nUpperCapMB) nMaxLogSizeMB = nUpperCapMB;
     int64_t nMaxLogSize = nMaxLogSizeMB * 1000000;
 
-    if (file && boost::filesystem::file_size(pathLog) > nMaxLogSize)
-    {
-        LogPrintf("ShrinkDebugFile: debug.log size is %.1f MB, shrinking to last 50 MB...\n",
-                  boost::filesystem::file_size(pathLog) / 1000000.0);
+    boost::system::error_code ec;
+    uintmax_t curSize = boost::filesystem::file_size(pathLog, ec);
+    if (ec || (int64_t)curSize <= nMaxLogSize)
+        return;
 
-        // Keep last 50MB when shrinking (reasonable amount for debugging)
-        std::vector <char> vch(50000000,0);
-        fseek(file, -((long)vch.size()), SEEK_END);
-        int nBytes = fread(begin_ptr(vch), 1, vch.size(), file);
-        fclose(file);
+    // Keep last 50 MB when shrinking.
+    const size_t nKeepBytes = 50 * 1000 * 1000;
 
-        file = fopen(pathLog.string().c_str(), "w");
-        if (file)
-        {
-            fwrite(begin_ptr(vch), 1, nBytes, file);
-            fclose(file);
-            LogPrintf("ShrinkDebugFile: Shrinking complete, kept %.1f MB\n", nBytes / 1000000.0);
-        }
+    FILE* src = fopen(pathLog.string().c_str(), "rb");
+    if (!src) return;
+
+    std::vector<char> vch(nKeepBytes, 0);
+    fseek(src, -(long)vch.size(), SEEK_END);
+    size_t nBytes = fread(begin_ptr(vch), 1, vch.size(), src);
+    fclose(src);
+
+    boost::filesystem::path pathTmp = pathLog;
+    pathTmp += ".tmp";
+    FILE* dst = fopen(pathTmp.string().c_str(), "wb");
+    if (!dst) return;
+    fwrite(begin_ptr(vch), 1, nBytes, dst);
+    fclose(dst);
+
+    boost::filesystem::rename(pathTmp, pathLog, ec);
+    if (ec) {
+        boost::filesystem::remove(pathTmp, ec);
+        return;
     }
-    else if (file != NULL)
-        fclose(file);
+
+    // Tell LogPrintStr to reopen the log on its next write so future output
+    // goes to the new (truncated) file instead of the unlinked inode.
+    fReopenDebugLog = true;
 }
 
 #ifdef WIN32


### PR DESCRIPTION
## Summary

Six focused changes to reduce IBD time and clean up the BIP 152 compact block relay path. Validated against a localhost sync run: full-cache flush stalls eliminated and no behavior regressions observed.

## Commits

### 1. Silence per-block `LogPrintf` calls on sync hot path
Four unconditional `LogPrintf` calls were firing for every PON header and every block connect/disconnect during IBD. Converted to `LogPrint` with categories so they only fire under `-debug=pon` or `-debug=fluxnode`.

- `src/pon/pon.cpp` — PON difficulty/adjustment traces (2× per PON header) → `LogPrint("pon", ...)`
- `src/fluxnode/fluxnode.cpp` — `FluxnodeCache::LogDebugData` gets an early-return on `LogAcceptCategory("fluxnode")` so the per-block string concatenation over `mapStartTxTracker` / `mapStartTxDOSTracker` is skipped when not debugging fluxnodes

### 2. Adopt Bitcoin Core's dbcache split to favor the in-memory UTXO set
Fluxd used to allocate 3/4 of `-dbcache` to the block tree DB whenever `-insightexplorer` was enabled, leaving only ~76 MiB for the in-memory UTXO cache at the default `-dbcache=450`. During IBD this caused frequent full-cache flushes (multi-second stalls every ~4k blocks).

Switched to Bitcoin Core's allocation:
- Block tree DB gets 1/8 of the total, capped at 2 MiB without txindex or 1024 MiB with txindex / insightexplorer
- Coin DB cache is capped at 8 MiB
- Remainder goes to the in-memory UTXO set

**Result at `-dbcache=450` with all indexes on:** UTXO cache grows from ~76 MiB → **~386 MiB**. At `-dbcache=1000` it reaches 867 MiB; at `-dbcache=2000` it's ~1.7 GiB. Verified zero flush stalls in a 10k-block IBD window vs one 8-second stall every ~4k blocks previously.

### 3. Implement BIP 152 low-bandwidth mode (peer-initiated compact blocks)
#266 shipped high-bandwidth compact block relay (unsolicited `cmpctblock` to up to three peers). This adds low-bandwidth mode: lets a peer request a compact block on demand via `getdata`, saving bandwidth for edge peers (light clients, metered connections) that haven't opted into high-bandwidth announcements.

- Adds `MSG_CMPCT_BLOCK` as a new inv type (value 11, not BIP 152's canonical 4 because type 4 is `"spork"` on the Flux network)
- `ProcessGetData` responds to `MSG_CMPCT_BLOCK` requests with a `cmpctblock` message when the block is within depth
- `IsFluxnodeType()` tightened to an explicit `[4, 10]` range so the new type isn't misrouted

Old fluxd peers that don't know type 11 treat it as unknown and silently ignore — no misbehavior, safe to deploy without coordination.

### 4. Early-return `CheckForExpired/UndoExpiredStartTx` when tracker is empty
Both functions are called on every `ConnectBlock` / `DisconnectBlock`. For most of chain history the relevant trackers are empty, so the iterate-and-conditionally-copy loops do no work but still pay for the `cs_main`-adjacent lock acquisition. The emptiness check runs under the lock so it races correctly with concurrent modifications.

### 5. Cap `debug.log` size and enforce it at runtime
Previously `ShrinkDebugFile()` only ran at startup and only when `-debug` was not set (`-shrinkdebugfile` default was `!fDebug`). With `debug=1` the log could grow without bound.

- `-maxdebugfilesize` upper cap is now **10 GiB when `-debug` is enabled** and **2 GiB otherwise**. The 500 MB default is unchanged.
- `-shrinkdebugfile` default flipped to `true` so the cap is enforced even when debug logging is on.
- `ShrinkDebugFile()` made safe to call at runtime via temp-file + atomic rename + `fReopenDebugLog`.
- Scheduled every 5 minutes via the existing `CScheduler`.

### 6. Harden BIP 152 compact block handling
Two fixes identified by an audit against Bitcoin Core's implementation:

**a. Clean up per-peer compact-block in-flight state on disconnect.** `FinalizeNode` previously iterated `mapPartialBlocks` but did nothing (a TODO comment acknowledged the gap). Peer-keyed cleanup is actually available via `listCompactBlocksInFlight`. Walk it, drop entries for the disconnecting peer, and drop the corresponding `mapPartialBlocks` / `mapPartialBlocksTime` entries only when no other peer is still working on the same block. Prevents a slow memory leak when peers churn mid-reconstruction.

**b. Unify the compact-block depth constant** as `MAX_CMPCTBLOCK_DEPTH`, shared by the `cmpctblock` reception check and the new low-bandwidth `MSG_CMPCT_BLOCK` getdata response. Value is **100**, sized to roughly Bitcoin Core's ~50-minute wall-clock window at fluxd's 30-second PON block spacing (Bitcoin uses 5 at 10-minute blocks). The prior reception value of 10 covered only ~5 minutes on PON — too narrow for typical mempool turnover.

## Config / operator impact

- No config changes required.
- Users keeping the default `-dbcache=450` will see their in-memory UTXO cache jump from ~76 MiB → ~386 MiB on restart.
- BIP 152 changes are backwards-compatible — old peers silently ignore the new inv type.

## Test plan

- [x] Full build under GCC 13.3 — clean
- [x] Localhost IBD against a known-good peer: height 141k → 272k over several minutes, no crashes, no flush stalls, cache behavior matches expected split
- [x] Mainnet dry-run on a test node for longer-term stability
- [ ] Stress test: high peer churn to validate the in-flight cleanup path

## Related

- Builds on #244 (write-after-disconnect flush) which is already on master.
- Extends #266 (BIP 152 high-bandwidth mode) with the low-bandwidth + hardening follow-ups.
- Noted follow-ups not in this PR:
  - Pre-validation HB announcement timing (bigger restructure of announce vs ConnectBlock ordering)
  - Client-side `MSG_CMPCT_BLOCK` request path when peers advertise LB mode
  - Periodic `pblocktree` compaction (separate change — the block index LevelDB bloats to ~14 GiB without manual compaction during heavy IBD)
