### PR TITLE
Clean up PR #278 review findings

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -8,24 +8,6 @@ $(package)_patches_darwin=darwin.diff
 $(package)_patches_linux=
 
 define $(package)_set_vars
-$(package)_config_opts_release=variant=release
-$(package)_config_opts_debug=variant=debug
-$(package)_config_opts=--layout=system
-$(package)_config_opts+=threading=multi link=static -sNO_BZIP2=1 -sNO_ZLIB=1
-$(package)_config_opts_linux=threadapi=pthread runtime-link=shared
-$(package)_config_opts_darwin=--toolset=darwin-4.2.1 runtime-link=shared
-$(package)_config_opts_mingw32=binary-format=pe target-os=windows threadapi=win32 runtime-link=static
-$(package)_config_opts_x86_64_mingw32=address-model=64
-$(package)_config_opts_i686_mingw32=address-model=32
-$(package)_config_opts_i686_linux=address-model=32 architecture=x86
-$(package)_toolset_$(host_os)=gcc
-$(package)_archiver_$(host_os)=$($(package)_ar)
-$(package)_toolset_darwin=darwin
-$(package)_archiver_darwin=$($(package)_libtool)
-$(package)_config_libraries=chrono,filesystem,program_options,system,thread,test
-$(package)_cxxflags=-std=c++11 -fvisibility=hidden
-$(package)_cxxflags_linux=-fPIC
-$(package)_cxxflags_freebsd=-fPIC
 endef
 
 define $(package)_preprocess_cmds
@@ -37,14 +19,14 @@ define $(package)_preprocess_cmds_darwin
 endef
 
 define $(package)_config_cmds
-  ./bootstrap.sh --without-icu --with-libraries=$($(package)_config_libraries) && \
-  sed -i -e "s|using gcc ;|using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;|" project-config.jam
+  echo "Header-only install, skipping bootstrap"
 endef
 
 define $(package)_build_cmds
-  ./b2 -d2 -j2 -d1 --prefix=$($(package)_staging_prefix_dir) $($(package)_config_opts) stage
+  echo "Header-only install, skipping build"
 endef
 
 define $(package)_stage_cmds
-  ./b2 -d0 -j4 --prefix=$($(package)_staging_prefix_dir) $($(package)_config_opts) install
+  mkdir -p $($(package)_staging_prefix_dir)/include && \
+  cp -r boost $($(package)_staging_prefix_dir)/include
 endef

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -221,9 +221,8 @@ bool CAlert::ProcessAlert(const std::vector<unsigned char>& alertKey, bool fThre
         }
 
         // Check if this alert has been cancelled
-        for (PAIRTYPE(const uint256, CAlert)& item : mapAlerts)
+        for (auto& [hash, alert] : mapAlerts)
         {
-            const CAlert& alert = item.second;
             if (alert.Cancels(*this))
             {
                 LogPrint("alert", "alert already cancelled by %d\n", alert.nID);

--- a/src/fluxd.cpp
+++ b/src/fluxd.cpp
@@ -1,6 +1,4 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-#include <vector>
-#include <thread>
 // Copyright (c) 2009-2013 The Bitcoin Core developers
 // Copyright (c) 2018-2022 The Flux Developers
 // Distributed under the MIT software license, see the accompanying

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -650,12 +650,12 @@ void CleanupBlockRevFiles()
     // keeping a separate counter.  Once we hit a gap (or if 0 doesn't exist)
     // start removing block files.
     int nContigCounter = 0;
-    for (const PAIRTYPE(string, path)& item : mapBlockFiles) {
-        if (atoi(item.first) == nContigCounter) {
+    for (const auto& [fileIndex, filePath] : mapBlockFiles) {
+        if (atoi(fileIndex) == nContigCounter) {
             nContigCounter++;
             continue;
         }
-        remove(item.second);
+        remove(filePath);
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6051,15 +6051,13 @@ bool static LoadBlockIndexDB()
     // Calculate nChainWork
     vector<pair<int, CBlockIndex*> > vSortedByHeight;
     vSortedByHeight.reserve(mapBlockIndex.size());
-    for (const PAIRTYPE(uint256, CBlockIndex*)& item : mapBlockIndex)
+    for (const auto& [hash, pindex] : mapBlockIndex)
     {
-        CBlockIndex* pindex = item.second;
         vSortedByHeight.push_back(make_pair(pindex->nHeight, pindex));
     }
     sort(vSortedByHeight.begin(), vSortedByHeight.end());
-    for (const PAIRTYPE(int, CBlockIndex*)& item : vSortedByHeight)
+    for (const auto& [height, pindex] : vSortedByHeight)
     {
-        CBlockIndex* pindex = item.second;
         pindex->nChainWork = (pindex->pprev ? pindex->pprev->nChainWork : 0) + GetBlockProof(*pindex);
         // We can link the chain of blocks for which we've received transactions at some point.
         // Pruned nodes may have deleted the block.
@@ -6143,9 +6141,8 @@ bool static LoadBlockIndexDB()
     // Check presence of blk files
     LogPrintf("Checking all blk files are present...\n");
     set<int> setBlkDataFiles;
-    for (const PAIRTYPE(uint256, CBlockIndex*)& item : mapBlockIndex)
+    for (const auto& [hash, pindex] : mapBlockIndex)
     {
-        CBlockIndex* pindex = item.second;
         if (pindex->nStatus & BLOCK_HAVE_DATA) {
             setBlkDataFiles.insert(pindex->nFile);
         }
@@ -6181,9 +6178,8 @@ bool static LoadBlockIndexDB()
     fTimestampIndex = fInsightExplorer;
 
     // Fill in-memory data
-    for (const PAIRTYPE(uint256, CBlockIndex*)& item : mapBlockIndex)
+    for (const auto& [hash, pindex] : mapBlockIndex)
     {
-        CBlockIndex* pindex = item.second;
         // - This relationship will always be true even if pprev has multiple
         //   children, because hashSproutAnchor is technically a property of pprev,
         //   not its children.
@@ -6873,9 +6869,8 @@ std::string GetWarnings(const std::string& strFor)
     // Alerts
     {
         LOCK(cs_mapAlerts);
-        for (PAIRTYPE(const uint256, CAlert)& item : mapAlerts)
+        for (auto& [alertHash, alert] : mapAlerts)
         {
-            const CAlert& alert = item.second;
             if (alert.AppliesToMe() && alert.nPriority > nPriority)
             {
                 nPriority = alert.nPriority;
@@ -7228,8 +7223,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         // Relay alerts
         {
             LOCK(cs_mapAlerts);
-            for (PAIRTYPE(const uint256, CAlert)& item : mapAlerts)
-                item.second.RelayTo(pfrom);
+            for (auto& [alertHash, alert] : mapAlerts)
+                alert.RelayTo(pfrom);
         }
 
         pfrom->fSuccessfullyConnected = true;

--- a/src/mempool_limit.h
+++ b/src/mempool_limit.h
@@ -10,7 +10,6 @@
 #include <set>
 #include <vector>
 
-#include "boost/optional.hpp"
 #include "primitives/transaction.h"
 #include "uint256.h"
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1,13 +1,4 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-#include <vector>
-#include <condition_variable>
-#include <mutex>
-#include <condition_variable>
-#include <thread>
-#include <condition_variable>
-#include <chrono>
-#include <mutex>
-#include <condition_variable>
 // Copyright (c) 2009-2014 The Bitcoin Core developers
 // Copyright (c) 2018-2022 The Flux Developers
 // Distributed under the MIT software license, see the accompanying

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -485,12 +485,12 @@ UniValue getnetworkinfo(const UniValue& params, bool fHelp)
     UniValue localAddresses(UniValue::VARR);
     {
         LOCK(cs_mapLocalHost);
-        for (const PAIRTYPE(CNetAddr, LocalServiceInfo) &item : mapLocalHost)
+        for (const auto& [addr, serviceInfo] : mapLocalHost)
         {
             UniValue rec(UniValue::VOBJ);
-            rec.pushKV("address", item.first.ToString());
-            rec.pushKV("port", item.second.nPort);
-            rec.pushKV("score", item.second.nScore);
+            rec.pushKV("address", addr.ToString());
+            rec.pushKV("port", serviceInfo.nPort);
+            rec.pushKV("score", serviceInfo.nScore);
             localAddresses.push_back(rec);
         }
     }

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -90,16 +90,16 @@ void RPCTypeCheckObj(const UniValue& o,
                   const map<string, UniValue::VType>& typesExpected,
                   bool fAllowNull)
 {
-    for (const PAIRTYPE(string, UniValue::VType)& t : typesExpected)
+    for (const auto& [fieldName, expectedType] : typesExpected)
     {
-        const UniValue& v = find_value(o, t.first);
+        const UniValue& v = find_value(o, fieldName);
         if (!fAllowNull && v.isNull())
-            throw JSONRPCError(RPC_TYPE_ERROR, strprintf("Missing %s", t.first));
+            throw JSONRPCError(RPC_TYPE_ERROR, strprintf("Missing %s", fieldName));
 
-        if (!((v.type() == t.second) || (fAllowNull && (v.isNull()))))
+        if (!((v.type() == expectedType) || (fAllowNull && (v.isNull()))))
         {
             string err = strprintf("Expected type %s for %s, got %s",
-                                   uvTypeName(t.second), t.first, uvTypeName(v.type()));
+                                   uvTypeName(expectedType), fieldName, uvTypeName(v.type()));
             throw JSONRPCError(RPC_TYPE_ERROR, err);
         }
     }
@@ -171,9 +171,8 @@ std::string CRPCTable::help(const std::string& strCommand) const
         vCommands.push_back(make_pair(mi->second->category + mi->first, mi->second));
     sort(vCommands.begin(), vCommands.end());
 
-    for (const PAIRTYPE(string, const CRPCCommand*)& command : vCommands)
+    for (const auto& [sortKey, pcmd] : vCommands)
     {
-        const CRPCCommand *pcmd = command.second;
         string strMethod = pcmd->name;
         // We already filter duplicates, but these deprecated screw up the sort order
         if (strMethod.find("label") != string::npos)

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -70,9 +70,8 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
 
     // Scan templates
     const CScript& script1 = scriptPubKey;
-    for (const PAIRTYPE(txnouttype, CScript)& tplate : mTemplates)
+    for (const auto& [txType, script2] : mTemplates)
     {
-        const CScript& script2 = tplate.second;
         vSolutionsRet.clear();
 
         opcodetype opcode1, opcode2;
@@ -86,7 +85,7 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
             if (pc1 == script1.end() && pc2 == script2.end())
             {
                 // Found a match
-                typeRet = tplate.first;
+                typeRet = txType;
                 if (typeRet == TX_MULTISIG)
                 {
                     // Additional checks for TX_MULTISIG:

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -76,38 +76,38 @@ static void potential_deadlock_detected(const std::pair<void*, void*>& mismatch,
 
     LogPrintf("POTENTIAL DEADLOCK DETECTED\n");
     LogPrintf("Previous lock order was:\n");
-    for (const PAIRTYPE(void*, CLockLocation) & i : s2) {
-        if (i.first == mismatch.first) {
+    for (const auto& [lockPtr, lockLoc] :s2) {
+        if (lockPtr == mismatch.first) {
             LogPrintf(" (1)");
-            if (!firstLocked && secondLocked && i.second.fTry)
+            if (!firstLocked && secondLocked && lockLoc.fTry)
                 onlyMaybeDeadlock = true;
             firstLocked = true;
         }
-        if (i.first == mismatch.second) {
+        if (lockPtr == mismatch.second) {
             LogPrintf(" (2)");
-            if (!secondLocked && firstLocked && i.second.fTry)
+            if (!secondLocked && firstLocked && lockLoc.fTry)
                 onlyMaybeDeadlock = true;
             secondLocked = true;
         }
-        LogPrintf(" %s\n", i.second.ToString());
+        LogPrintf(" %s\n", lockLoc.ToString());
     }
     firstLocked = false;
     secondLocked = false;
     LogPrintf("Current lock order is:\n");
-    for (const PAIRTYPE(void*, CLockLocation) & i : s1) {
-        if (i.first == mismatch.first) {
+    for (const auto& [lockPtr, lockLoc] :s1) {
+        if (lockPtr == mismatch.first) {
             LogPrintf(" (1)");
-            if (!firstLocked && secondLocked && i.second.fTry)
+            if (!firstLocked && secondLocked && lockLoc.fTry)
                 onlyMaybeDeadlock = true;
             firstLocked = true;
         }
-        if (i.first == mismatch.second) {
+        if (lockPtr == mismatch.second) {
             LogPrintf(" (2)");
-            if (!secondLocked && firstLocked && i.second.fTry)
+            if (!secondLocked && firstLocked && lockLoc.fTry)
                 onlyMaybeDeadlock = true;
             secondLocked = true;
         }
-        LogPrintf(" %s\n", i.second.ToString());
+        LogPrintf(" %s\n", lockLoc.ToString());
     }
     assert(onlyMaybeDeadlock);
 }
@@ -122,16 +122,16 @@ static void push_lock(void* c, const CLockLocation& locklocation, bool fTry)
     (*lockstack).push_back(std::make_pair(c, locklocation));
 
     if (!fTry) {
-        for (const PAIRTYPE(void*, CLockLocation) & i : (*lockstack)) {
-            if (i.first == c)
+        for (const auto& [lockPtr, lockLoc] :(*lockstack)) {
+            if (lockPtr == c)
                 break;
 
-            std::pair<void*, void*> p1 = std::make_pair(i.first, c);
+            std::pair<void*, void*> p1 = std::make_pair(lockPtr, c);
             if (lockorders.count(p1))
                 continue;
             lockorders[p1] = (*lockstack);
 
-            std::pair<void*, void*> p2 = std::make_pair(c, i.first);
+            std::pair<void*, void*> p2 = std::make_pair(c, lockPtr);
             if (lockorders.count(p2))
                 potential_deadlock_detected(p1, lockorders[p2], lockorders[p1]);
         }
@@ -159,15 +159,15 @@ void LeaveCritical()
 std::string LocksHeld()
 {
     std::string result;
-    for (const PAIRTYPE(void*, CLockLocation) & i : *lockstack)
-        result += i.second.ToString() + std::string("\n");
+    for (const auto& [lockPtr, lockLoc] :*lockstack)
+        result += lockLoc.ToString() + std::string("\n");
     return result;
 }
 
 void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs)
 {
-    for (const PAIRTYPE(void*, CLockLocation) & i : *lockstack)
-        if (i.first == cs)
+    for (const auto& [lockPtr, lockLoc] :*lockstack)
+        if (lockPtr == cs)
             return;
     fprintf(stderr, "Assertion failed: lock %s not held in %s:%i; locks held:\n%s", pszName, pszFile, nLine, LocksHeld().c_str());
     abort();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -390,10 +390,10 @@ void ParseParameters(int argc, const char* const argv[])
     }
 
     // New 0.6 features:
-    for (const PAIRTYPE(string,string)& entry : mapArgs)
+    for (const auto& [key, value] : mapArgs)
     {
         // interpret -nofoo as -foo=0 (and -nofoo=0 as -foo=1) as long as -foo not set
-        InterpretNegativeSetting(entry.first, mapArgs);
+        InterpretNegativeSetting(key, mapArgs);
     }
 }
 

--- a/src/util/fs.cpp
+++ b/src/util/fs.cpp
@@ -103,7 +103,7 @@ bool FileLock::TryLock()
     if (m_hFile == INVALID_HANDLE_VALUE) {
         return false;
     }
-    _OVERLAPPED overlapped = {};
+    OVERLAPPED overlapped = {};
     if (!LockFileEx(m_hFile, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0,
         std::numeric_limits<DWORD>::max(), std::numeric_limits<DWORD>::max(), &overlapped)) {
         m_reason = GetErrorReason();

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -20,8 +20,6 @@
 #define UEND(a)             ((unsigned char*)&((&(a))[1]))
 #define ARRAYLEN(array)     (sizeof(array)/sizeof((array)[0]))
 
-/** This is needed because the foreach macro can't get over the comma in pair<t1, t2> */
-#define PAIRTYPE(t1, t2)    std::pair<t1, t2>
 
 /** Used by SanitizeString() */
 enum SafeChars

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -103,8 +103,8 @@ void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
     entry.pushKV("walletconflicts", conflicts);
     entry.pushKV("time", wtx.GetTxTime());
     entry.pushKV("timereceived", (int64_t)wtx.nTimeReceived);
-    for (const PAIRTYPE(string,string)& item : wtx.mapValue)
-        entry.pushKV(item.first, item.second);
+    for (const auto& [key, value] : wtx.mapValue)
+        entry.pushKV(key, value);
 
     entry.pushKV("vJoinSplit", TxJoinSplitToJSON(wtx));
 }
@@ -1740,9 +1740,9 @@ UniValue listaccounts(const UniValue& params, bool fHelp)
             includeWatchonly = includeWatchonly | ISMINE_WATCH_ONLY;
 
     map<string, CAmount> mapAccountBalances;
-    for (const PAIRTYPE(CTxDestination, CAddressBookData)& entry : pwalletMain->mapAddressBook) {
-        if (IsMine(*pwalletMain, entry.first) & includeWatchonly) // This address belongs to me
-            mapAccountBalances[entry.second.name] = 0;
+    for (const auto& [dest, addrBookData] : pwalletMain->mapAddressBook) {
+        if (IsMine(*pwalletMain, dest) & includeWatchonly) // This address belongs to me
+            mapAccountBalances[addrBookData.name] = 0;
     }
 
     for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
@@ -1775,8 +1775,8 @@ UniValue listaccounts(const UniValue& params, bool fHelp)
         mapAccountBalances[entry.strAccount] += entry.nCreditDebit;
 
     UniValue ret(UniValue::VOBJ);
-    for (const PAIRTYPE(string, CAmount)& accountBalance : mapAccountBalances) {
-        ret.pushKV(accountBalance.first, ValueFromAmount(accountBalance.second));
+    for (const auto& [accountName, balance] : mapAccountBalances) {
+        ret.pushKV(accountName, ValueFromAmount(balance));
     }
     return ret;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4063,7 +4063,7 @@ std::map<CTxDestination, CAmount> CWallet::GetAddressBalances()
                 if(!ExtractDestination(pcoin->vout[i].scriptPubKey, addr))
                     continue;
 
-                CAmount n = IsSpent(walletEntry.first, i) ? 0 : pcoin->vout[i].nValue;
+                CAmount n = IsSpent(txid, i) ? 0 : pcoin->vout[i].nValue;
 
                 if (!balances.count(addr))
                     balances[addr] = 0;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1372,8 +1372,8 @@ void CWallet::MarkDirty()
 {
     {
         LOCK(cs_wallet);
-        for (PAIRTYPE(const uint256, CWalletTx)& item : mapWallet)
-            item.second.MarkDirty();
+        for (auto& [txid, wtx] : mapWallet)
+            wtx.MarkDirty();
     }
 }
 
@@ -2569,10 +2569,8 @@ void CWallet::ReacceptWalletTransactions()
     std::map<int64_t, CWalletTx*> mapSorted;
 
     // Sort pending wallet transactions based on their initial wallet insertion order
-    for (PAIRTYPE(const uint256, CWalletTx)& item : mapWallet)
+    for (auto& [wtxid, wtx] : mapWallet)
     {
-        const uint256& wtxid = item.first;
-        CWalletTx& wtx = item.second;
         assert(wtx.GetHash() == wtxid);
 
         int nDepth = wtx.GetDepthInMainChain();
@@ -2583,9 +2581,9 @@ void CWallet::ReacceptWalletTransactions()
     }
 
     // Try to add wallet transactions to memory pool
-    for (PAIRTYPE(const int64_t, CWalletTx*)& item : mapSorted)
+    for (auto& [orderPos, pwtx] : mapSorted)
     {
-        CWalletTx& wtx = *(item.second);
+        CWalletTx& wtx = *pwtx;
 
         LOCK(mempool.cs);
         wtx.AcceptToMemoryPool(false);
@@ -2819,17 +2817,16 @@ std::vector<uint256> CWallet::ResendWalletTransactionsBefore(int64_t nTime)
     LOCK(cs_wallet);
     // Sort them in chronological order
     multimap<unsigned int, CWalletTx*> mapSorted;
-    for (PAIRTYPE(const uint256, CWalletTx)& item : mapWallet)
+    for (auto& [txid, wtx] : mapWallet)
     {
-        CWalletTx& wtx = item.second;
         // Don't rebroadcast if newer than nTime:
         if (wtx.nTimeReceived > nTime)
             continue;
         mapSorted.insert(make_pair(wtx.nTimeReceived, &wtx));
     }
-    for (PAIRTYPE(const unsigned int, CWalletTx*)& item : mapSorted)
+    for (auto& [timeReceived, pwtx] : mapSorted)
     {
-        CWalletTx& wtx = *item.second;
+        CWalletTx& wtx = *pwtx;
         if (wtx.RelayWalletTransaction())
             result.push_back(wtx.GetHash());
     }
@@ -3514,14 +3511,14 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                     }
                     return false;
                 }
-                for (PAIRTYPE(const CWalletTx*, unsigned int) pcoin : setCoins)
+                for (const auto& [pwtx, nOut] : setCoins)
                 {
-                    CAmount nCredit = pcoin.first->vout[pcoin.second].nValue;
+                    CAmount nCredit = pwtx->vout[nOut].nValue;
                     //The coin age after the next block (depth+1) is used instead of the current,
                     //reflecting an assumption the user would accept a bit more delay for
                     //a chance at a free transaction.
                     //But mempool inputs might still be in the mempool, so their age stays 0
-                    int age = pcoin.first->GetDepthInMainChain();
+                    int age = pwtx->GetDepthInMainChain();
                     if (age != 0)
                         age += 1;
                     dPriority += (double)nCredit * age;
@@ -3607,8 +3604,8 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                 //
                 // Note how the sequence number is set to max()-1 so that the
                 // nLockTime set above actually works.
-                for (const PAIRTYPE(const CWalletTx*,unsigned int)& coin : setCoins)
-                    txNew.vin.push_back(CTxIn(coin.first->GetHash(),coin.second,CScript(),
+                for (const auto& [pwtx, nOut] : setCoins)
+                    txNew.vin.push_back(CTxIn(pwtx->GetHash(),nOut,CScript(),
                                               std::numeric_limits<unsigned int>::max()-1));
 
                 // Check mempooltxinputlimit to avoid creating a transaction which the local mempool rejects
@@ -3633,13 +3630,13 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                 // Sign
                 int nIn = 0;
                 CTransaction txNewConst(txNew);
-                for (const PAIRTYPE(const CWalletTx*,unsigned int)& coin : setCoins)
+                for (const auto& [pwtx, nOut] : setCoins)
                 {
                     bool signSuccess;
-                    const CScript& scriptPubKey = coin.first->vout[coin.second].scriptPubKey;
+                    const CScript& scriptPubKey = pwtx->vout[nOut].scriptPubKey;
                     SignatureData sigdata;
                     if (sign)
-                        signSuccess = ProduceSignature(TransactionSignatureCreator(this, &txNewConst, nIn, coin.first->vout[coin.second].nValue, SIGHASH_ALL), scriptPubKey, sigdata, consensusBranchId);
+                        signSuccess = ProduceSignature(TransactionSignatureCreator(this, &txNewConst, nIn, pwtx->vout[nOut].nValue, SIGHASH_ALL), scriptPubKey, sigdata, consensusBranchId);
                     else
                         signSuccess = ProduceSignature(DummySignatureCreator(this), scriptPubKey, sigdata, consensusBranchId);
 
@@ -3874,9 +3871,9 @@ bool CWallet::DelAddressBook(const CTxDestination& address)
         {
             // Delete destdata tuples associated with address
             std::string strAddress = EncodeDestination(address);
-            for (const PAIRTYPE(string, string) &item : mapAddressBook[address].destdata)
+            for (const auto& [key, value] : mapAddressBook[address].destdata)
             {
-                CWalletDB(strWalletFile).EraseDestData(strAddress, item.first);
+                CWalletDB(strWalletFile).EraseDestData(strAddress, key);
             }
         }
         mapAddressBook.erase(address);
@@ -4044,9 +4041,9 @@ std::map<CTxDestination, CAmount> CWallet::GetAddressBalances()
 
     {
         LOCK(cs_wallet);
-        for (PAIRTYPE(uint256, CWalletTx) walletEntry : mapWallet)
+        for (auto& [txid, wtx] : mapWallet)
         {
-            CWalletTx *pcoin = &walletEntry.second;
+            CWalletTx *pcoin = &wtx;
 
             if (!CheckFinalTx(*pcoin) || !pcoin->IsTrusted())
                 continue;
@@ -4084,9 +4081,9 @@ set< set<CTxDestination> > CWallet::GetAddressGroupings()
     set< set<CTxDestination> > groupings;
     set<CTxDestination> grouping;
 
-    for (PAIRTYPE(uint256, CWalletTx) walletEntry : mapWallet)
+    for (auto& [txid, wtx] : mapWallet)
     {
-        CWalletTx *pcoin = &walletEntry.second;
+        CWalletTx *pcoin = &wtx;
 
         if (pcoin->vin.size() > 0)
         {
@@ -4175,10 +4172,9 @@ std::set<CTxDestination> CWallet::GetAccountAddresses(const std::string& strAcco
 {
     LOCK(cs_wallet);
     set<CTxDestination> result;
-    for (const PAIRTYPE(CTxDestination, CAddressBookData)& item : mapAddressBook)
+    for (const auto& [address, addrBookData] : mapAddressBook)
     {
-        const CTxDestination& address = item.first;
-        const string& strName = item.second.name;
+        const string& strName = addrBookData.name;
         if (strName == strAccount)
             result.insert(address);
     }


### PR DESCRIPTION
## Summary

- **boost.mk**: Remove compiled library build (bootstrap/b2), switch to header-only install (`cp -r boost`). Only `signals2` and `multi_index` are used — both header-only. Boost depends step goes from several minutes (bootstrap + b2 compile) to seconds (header copy).
- **net.cpp**: Remove duplicate includes (4x `condition_variable`, 2x `mutex`, stray `vector`/`thread`/`chrono`) from bad rebase
- **fluxd.cpp**: Remove stray `vector`/`thread` includes interleaved in copyright block
- **mempool_limit.h**: Remove dead `boost/optional.hpp` include (code uses `std::optional`)
- **fs.cpp**: Use `OVERLAPPED` typedef instead of `_OVERLAPPED` struct tag (Windows)
- **PAIRTYPE macro removal**: Removed the pre-C++11 `PAIRTYPE(t1, t2)` macro from `utilstrencodings.h` and replaced all 34 usages across 10 files with C++20 structured bindings (e.g. `for (auto& [txid, wtx] : mapWallet)`)

## Test plan

- [x] Clean build on Ubuntu 25.04 with gcc-14 (`zcutil/build.sh -j16`) — all 4 binaries produced, zero errors
- [x] Verified zero Boost/OpenSSL shared library linkage via `ldd`
- [x] Stripped binary size identical to previous build (13,563,464 bytes)
- [x] Deployed to 6 test nodes — all synced at chain tip, CONFIRMED status, no errors
- [x] PAIRTYPE cleanup: clean build and deployed to test node, synced to tip, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)