### PR TITLE
Fix macOS build: bump OSX_MIN_VERSION and C++20 cleanup

### DIFF
--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -1,5 +1,5 @@
-OSX_MIN_VERSION=10.8
-OSX_SDK_VERSION=10.11
+OSX_MIN_VERSION=11.0
+OSX_SDK_VERSION=11.0
 OSX_SDK=$(SDK_PATH)/MacOSX$(OSX_SDK_VERSION).sdk
 LD64_VERSION=253.9
 darwin_CC=clang -target $(host) -mmacosx-version-min=$(OSX_MIN_VERSION) --sysroot $(OSX_SDK) -mlinker-version=$(LD64_VERSION)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2104,7 +2104,7 @@ UniValue walletpassphrase(const UniValue& params, bool fHelp)
     int64_t nSleepTime = params[1].get_int64();
     LOCK(cs_nWalletUnlockTime);
     nWalletUnlockTime = GetTime() + nSleepTime;
-    RPCRunLater("lockwallet", [pwalletMain]() { LockWallet(pwalletMain); }, nSleepTime);
+    RPCRunLater("lockwallet", []() { LockWallet(pwalletMain); }, nSleepTime);
 
     return NullUniValue;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3184,7 +3184,9 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int
     vector<pair<CAmount, pair<const CWalletTx*,unsigned int> > > vValue;
     CAmount nTotalLower = 0;
 
-    random_shuffle(vCoins.begin(), vCoins.end(), GetRandInt);
+    for (size_t i = vCoins.size(); i > 1; --i) {
+        std::swap(vCoins[i - 1], vCoins[GetRandInt(i)]);
+    }
 
     for (const COutput &output : vCoins)
     {


### PR DESCRIPTION
PR #278 swapped Boost filesystem for std::filesystem but did not raise the macOS deployment target. On macOS the std::filesystem symbols live in libc++.dylib and Apple only shipped them in 10.15+, so the headers mark std::filesystem::path et al. as unavailable for any target below 10.15. Two source patterns from the same migration also fail under -std=c++20.

- depends/hosts/darwin.mk: raise OSX_MIN_VERSION and OSX_SDK_VERSION from 10.8 / 10.11 to 11.0. Required for std::filesystem to be callable on macOS.

- src/wallet/rpcwallet.cpp: drop pwalletMain from a lambda capture list. C++20 forbids naming variables with non-automatic storage duration in a capture list; the body can reference the global directly.

- src/wallet/wallet.cpp: std::random_shuffle was removed in C++17. Replace with an explicit Fisher-Yates loop that reuses GetRandInt, preserving the original RNG and shuffle semantics.