### PR TITLE
fix: statically link libstdc++/libgcc so releases run on Ubuntu 20.04

### DIFF
--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -24,5 +24,6 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
+  sed -i.bak 's| -lstdc++||g' lib/pkgconfig/libzmq.pc && rm -f lib/pkgconfig/libzmq.pc.bak && \
   rm -rf bin share
 endef

--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -103,5 +103,9 @@ ld -v
 
 HOST="$HOST" BUILD="$BUILD" NO_PROTON="$PROTON_ARG" "$MAKE" "$@" -C ./depends/ V=1
 ./autogen.sh
+# Statically link libstdc++ and libgcc so binaries don't depend on the build
+# host's GCC libstdc++.so.6 version (e.g. GLIBCXX_3.4.29 from gcc-11 isn't
+# available on stock Ubuntu 20.04, which only ships GLIBCXX_3.4.28).
+LDFLAGS="${LDFLAGS:-} -static-libstdc++ -static-libgcc" \
 CONFIG_SITE="$PWD/depends/$HOST/share/config.site" ./configure "$HARDENING_ARG" "$LCOV_ARG" "$TEST_ARG" "$MINING_ARG" "$PROTON_ARG" $CONFIGURE_FLAGS CXXFLAGS='-g'
 "$MAKE" "$@" V=1


### PR DESCRIPTION
CI builds inside ubuntu:20.04 but installs gcc-11 from the ubuntu-toolchain-r/test PPA for C++20 support, which brings a newer libstdc++.so.6 into the build environment. The resulting fluxd dynamic-links against it and fails at runtime on stock Ubuntu 20.04 with "GLIBCXX_3.4.29 not found" / "CXXABI_1.3.13 not found".

- zcutil/build.sh: pass -static-libstdc++ -static-libgcc via LDFLAGS so the C++ runtime is baked into the binary, decoupling it from the build host's libstdc++ version.

- depends/packages/zeromq.mk: strip -lstdc++ from libzmq.pc Libs.private. pkg-config injects this into the link line, and an explicit -lstdc++ overrides -static-libstdc++ (which only affects gcc's implicit libstdc++ link). Removing it lets static-libstdc++ take effect.

Verified end-to-end by rebuilding the same source in a fresh ubuntu:20.04 container with these patches: ldd shows no libstdc++.so.6 dependency, max GLIBC required is 2.30, and the binary runs cleanly on stock ubuntu:20.04. No CI workflow changes needed.