### PR TITLE
Feat/pon vrf integration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -908,7 +908,7 @@ PKGCONFIG_LIBDIR_TEMP="$PKG_CONFIG_LIBDIR"
 unset PKG_CONFIG_LIBDIR
 PKG_CONFIG_LIBDIR="$PKGCONFIG_LIBDIR_TEMP"
 
-ac_configure_args="${ac_configure_args} --disable-shared --with-pic --with-bignum=no --enable-module-recovery"
+ac_configure_args="${ac_configure_args} --disable-shared --with-pic --with-bignum=no --enable-module-recovery --enable-module-vrf"
 AC_CONFIG_SUBDIRS([src/secp256k1 src/univalue])
 
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -397,6 +397,8 @@ libbitcoin_common_a_SOURCES = \
   core_read.cpp \
   core_write.cpp \
   hash.cpp \
+  crypto/ecvrf.cpp \
+  crypto/ecvrf.h \
   key.cpp \
   key_io.cpp \
   keystore.cpp \

--- a/src/chain.h
+++ b/src/chain.h
@@ -241,6 +241,8 @@ public:
     //! PON fields
     COutPoint nodesCollateral;
     std::vector<unsigned char> vchBlockSig;
+    //! PON-VRF: VRF output (committed to the block hash; fork-choice tie-breaker)
+    uint256 nodesVrfOutput;
 
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     uint32_t nSequenceId;
@@ -276,6 +278,7 @@ public:
         nSolution.clear();
         nodesCollateral.SetNull();
         vchBlockSig.clear();
+        nodesVrfOutput.SetNull();
     }
 
     CBlockIndex()
@@ -296,6 +299,7 @@ public:
         nSolution      = block.nSolution;
         nodesCollateral = block.nodesCollateral;
         vchBlockSig    = block.vchBlockSig;
+        nodesVrfOutput = block.nodesVrfOutput;
     }
 
     CDiskBlockPos GetBlockPos() const {
@@ -330,6 +334,7 @@ public:
         block.nSolution      = nSolution;
         block.nodesCollateral = nodesCollateral;
         block.vchBlockSig    = vchBlockSig;
+        block.nodesVrfOutput = nodesVrfOutput;
         return block;
     }
 
@@ -460,6 +465,11 @@ public:
         if (this->nVersion >= CBlockHeader::PON_VERSION) {
             READWRITE(nodesCollateral);
             READWRITE(vchBlockSig);
+            // PON-VRF: the VRF output is committed to the block hash, so it must be
+            // persisted to recompute the hash and to serve as the fork-choice tie-breaker.
+            if (this->nVersion >= CBlockHeader::PON_VRF_VERSION) {
+                READWRITE(nodesVrfOutput);
+            }
         }
 
         // Only read/write nSproutValue if the client version used to create
@@ -507,6 +517,7 @@ public:
         block.nSolution       = nSolution;
         block.nodesCollateral = nodesCollateral;
         block.vchBlockSig     = vchBlockSig;
+        block.nodesVrfOutput  = nodesVrfOutput;
         return block.GetHash();
     }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -151,7 +151,7 @@ public:
 
         consensus.vUpgrades[Consensus::UPGRADE_PON].nProtocolVersion = 170020;
         consensus.vUpgrades[Consensus::UPGRADE_PON].nActivationHeight = 2020000;
-        consensus.vUpgrades[Consensus::UPGRADE_PON_VRF].nProtocolVersion = 170020;
+        consensus.vUpgrades[Consensus::UPGRADE_PON_VRF].nProtocolVersion = 170022;
         consensus.vUpgrades[Consensus::UPGRADE_PON_VRF].nActivationHeight =
                 Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;  // TBD: set at scheduled network upgrade
         
@@ -395,7 +395,7 @@ public:
 
         consensus.vUpgrades[Consensus::UPGRADE_PON].nProtocolVersion = 170020;
         consensus.vUpgrades[Consensus::UPGRADE_PON].nActivationHeight = 800;
-        consensus.vUpgrades[Consensus::UPGRADE_PON_VRF].nProtocolVersion = 170020;
+        consensus.vUpgrades[Consensus::UPGRADE_PON_VRF].nProtocolVersion = 170022;
         consensus.vUpgrades[Consensus::UPGRADE_PON_VRF].nActivationHeight =
                 9999999;  // PLACEHOLDER — REPLACE with the scheduled testnet activation height (well above the current tip) before tagging the release
         
@@ -615,7 +615,7 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_PON].nProtocolVersion = 170020;
         consensus.vUpgrades[Consensus::UPGRADE_PON].nActivationHeight =
                 Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
-        consensus.vUpgrades[Consensus::UPGRADE_PON_VRF].nProtocolVersion = 170020;
+        consensus.vUpgrades[Consensus::UPGRADE_PON_VRF].nProtocolVersion = 170022;
         consensus.vUpgrades[Consensus::UPGRADE_PON_VRF].nActivationHeight =
                 Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;  // TBD: set at scheduled network upgrade
         

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -397,7 +397,7 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_PON].nActivationHeight = 800;
         consensus.vUpgrades[Consensus::UPGRADE_PON_VRF].nProtocolVersion = 170020;
         consensus.vUpgrades[Consensus::UPGRADE_PON_VRF].nActivationHeight =
-                Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;  // TBD: set at scheduled network upgrade
+                9999999;  // PLACEHOLDER — REPLACE with the scheduled testnet activation height (well above the current tip) before tagging the release
         
         // PON subsidy parameters (testnet)
         consensus.nPONInitialSubsidy = 14;  // 14 FLUX per block initially

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -151,6 +151,9 @@ public:
 
         consensus.vUpgrades[Consensus::UPGRADE_PON].nProtocolVersion = 170020;
         consensus.vUpgrades[Consensus::UPGRADE_PON].nActivationHeight = 2020000;
+        consensus.vUpgrades[Consensus::UPGRADE_PON_VRF].nProtocolVersion = 170020;
+        consensus.vUpgrades[Consensus::UPGRADE_PON_VRF].nActivationHeight =
+                Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;  // TBD: set at scheduled network upgrade
         
         // PON subsidy parameters
         consensus.nPONInitialSubsidy = 14;  // 14 FLUX per block initially
@@ -392,6 +395,9 @@ public:
 
         consensus.vUpgrades[Consensus::UPGRADE_PON].nProtocolVersion = 170020;
         consensus.vUpgrades[Consensus::UPGRADE_PON].nActivationHeight = 800;
+        consensus.vUpgrades[Consensus::UPGRADE_PON_VRF].nProtocolVersion = 170020;
+        consensus.vUpgrades[Consensus::UPGRADE_PON_VRF].nActivationHeight =
+                Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;  // TBD: set at scheduled network upgrade
         
         // PON subsidy parameters (testnet)
         consensus.nPONInitialSubsidy = 14;  // 14 FLUX per block initially
@@ -609,6 +615,9 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_PON].nProtocolVersion = 170020;
         consensus.vUpgrades[Consensus::UPGRADE_PON].nActivationHeight =
                 Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
+        consensus.vUpgrades[Consensus::UPGRADE_PON_VRF].nProtocolVersion = 170020;
+        consensus.vUpgrades[Consensus::UPGRADE_PON_VRF].nActivationHeight =
+                Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;  // TBD: set at scheduled network upgrade
         
         // PON subsidy parameters (regtest)
         consensus.nPONInitialSubsidy = 14;  // 14 FLUX per block initially

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -35,6 +35,7 @@ enum UpgradeIndex {
     UPGRADE_HALVING,
     UPGRADE_P2SHNODES,
     UPGRADE_PON,  // Proof of Node activation
+    UPGRADE_PON_VRF,  // PON VRF leader election (anti-grind)
     // NOTE: Also add new upgrades to NetworkUpgradeInfo in upgrades.cpp
     MAX_NETWORK_UPGRADES
 };

--- a/src/consensus/upgrades.cpp
+++ b/src/consensus/upgrades.cpp
@@ -64,6 +64,11 @@ const struct NUInfo NetworkUpgradeInfo[Consensus::MAX_NETWORK_UPGRADES] = {
             /*.nBranchId =*/ 0x76b809bb,
             /*.strName =*/ "PON",
             /*.strInfo =*/ "Proof of Node activation",
+    },
+    {
+            /*.nBranchId =*/ 0x76b809bb,
+            /*.strName =*/ "PON-VRF",
+            /*.strInfo =*/ "PON VRF leader election (anti-grind)",
     }
 };
 

--- a/src/crypto/ecvrf.cpp
+++ b/src/crypto/ecvrf.cpp
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 The Flux Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+#include "crypto/ecvrf.h"
+
+#include <secp256k1.h>
+#include <secp256k1_vrf.h>
+
+#include <cstring>
+
+namespace {
+// Verify-only context, sufficient for pubkey parse/serialize used below.
+// secp256k1_vrf_prove/verify themselves are context-free. C++11 guarantees
+// thread-safe initialisation of this function-local static.
+secp256k1_context* VrfContext()
+{
+    static secp256k1_context* ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+    return ctx;
+}
+} // namespace
+
+bool ECVRF_Prove(const CKey& sk, const CPubKey& pk, const uint256& seed,
+                 std::vector<unsigned char>& proofOut, uint256& outputOut)
+{
+    if (sk.size() != 32) return false;
+
+    secp256k1_pubkey parsed;
+    if (!secp256k1_ec_pubkey_parse(VrfContext(), &parsed, pk.begin(), pk.size())) return false;
+
+    unsigned char proof[81];
+    if (!secp256k1_vrf_prove(proof, sk.begin(), &parsed, seed.begin(), 32)) return false;
+
+    unsigned char beta[32];
+    if (!secp256k1_vrf_proof_to_hash(beta, proof)) return false;
+
+    proofOut.assign(proof, proof + 81);
+    std::memcpy(outputOut.begin(), beta, 32);
+    return true;
+}
+
+bool ECVRF_Verify(const CPubKey& pk, const uint256& seed,
+                  const std::vector<unsigned char>& proof, uint256& outputOut)
+{
+    if (proof.size() != 81) return false;
+
+    // The verify API takes a 33-byte compressed pubkey.
+    unsigned char pk33[33];
+    if (pk.size() == 33) {
+        std::memcpy(pk33, pk.begin(), 33);
+    } else {
+        secp256k1_pubkey parsed;
+        size_t len = 33;
+        if (!secp256k1_ec_pubkey_parse(VrfContext(), &parsed, pk.begin(), pk.size())) return false;
+        if (!secp256k1_ec_pubkey_serialize(VrfContext(), pk33, &len, &parsed, SECP256K1_EC_COMPRESSED)) return false;
+    }
+
+    unsigned char beta[32];
+    if (!secp256k1_vrf_verify(beta, proof.data(), pk33, seed.begin(), 32)) return false;
+
+    std::memcpy(outputOut.begin(), beta, 32);
+    return true;
+}

--- a/src/crypto/ecvrf.h
+++ b/src/crypto/ecvrf.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 The Flux Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_CRYPTO_ECVRF_H
+#define BITCOIN_CRYPTO_ECVRF_H
+
+#include "key.h"
+#include "pubkey.h"
+#include "uint256.h"
+
+#include <vector>
+
+// ECVRF-SECP256K1-SHA256-TAI (CFRG VRF draft-05, suite 0xFE), keyed to the fluxnode
+// operator key. Backed by the vendored secp256k1 VRF module (src/secp256k1/src/modules/vrf).
+//   proof  : 81 bytes (Gamma || c || s), to be carried in the block header
+//   output : 32-byte VRF value (beta), compared against the PON target for eligibility
+//
+// The output is unforgeable and not grindable: it is determined by the operator secret key
+// and `seed` (an epoch seed the proposer does not author), so the producer cannot bias it.
+
+/** Prove: compute (proof, output) for operator key (sk,pk) over `seed`. Returns false on error. */
+bool ECVRF_Prove(const CKey& sk, const CPubKey& pk, const uint256& seed,
+                 std::vector<unsigned char>& proofOut, uint256& outputOut);
+
+/** Verify: check `proof` for `pk` over `seed`; on success fills `outputOut` (beta). */
+bool ECVRF_Verify(const CPubKey& pk, const uint256& seed,
+                  const std::vector<unsigned char>& proof, uint256& outputOut);
+
+#endif // BITCOIN_CRYPTO_ECVRF_H

--- a/src/gtest/test_pon.cpp
+++ b/src/gtest/test_pon.cpp
@@ -13,6 +13,11 @@
 #include "chain.h"
 #include "uint256.h"
 #include "amount.h"
+#include "crypto/ecvrf.h"
+#include "key.h"
+#include "pubkey.h"
+#include "streams.h"
+#include "version.h"
 
 // Define node tiers for testing (from fluxnode/fluxnode.h)
 #ifndef CUMULUS
@@ -550,4 +555,94 @@ TEST_F(PONTest, VrfForkChoiceEqualOutputUndecided) {
     CBlockIndex b = MakeVrfIndex(100, same);
     // Identical VRF output -> no decision; caller falls back to first-seen.
     EXPECT_EQ(ComparePonForkChoice(&a, &b), 0);
+}
+
+// --- PON-VRF block-header serialization + hash-commitment -----------------------------
+
+static CBlockHeader MakeVrfHeader() {
+    CBlockHeader h;
+    h.nVersion = CBlockHeader::PON_VRF_VERSION;
+    h.hashPrevBlock = uint256S("0x01");
+    h.hashMerkleRoot = uint256S("0x02");
+    h.hashFinalSaplingRoot = uint256S("0x03");
+    h.nTime = 1700000000;
+    h.nBits = 0x1d00ffff;
+    h.nodesCollateral = COutPoint(uint256S("0x04"), 1);
+    h.nodesVrfOutput = uint256S("0x0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a");
+    h.nodesVrfProof = std::vector<unsigned char>(81, 0x77);
+    h.vchBlockSig = std::vector<unsigned char>(64, 0x99);
+    return h;
+}
+
+TEST_F(PONTest, VrfBlockHeaderSerializationRoundTrip) {
+    CBlockHeader h = MakeVrfHeader();
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << h;
+    CBlockHeader h2;
+    ss >> h2;
+    EXPECT_EQ(h2.nVersion, h.nVersion);
+    EXPECT_EQ(h2.nodesCollateral, h.nodesCollateral);
+    EXPECT_EQ(h2.nodesVrfOutput, h.nodesVrfOutput);
+    EXPECT_EQ(h2.nodesVrfProof, h.nodesVrfProof);
+    EXPECT_EQ(h2.vchBlockSig, h.vchBlockSig);
+    EXPECT_EQ(h2.GetHash(), h.GetHash());
+}
+
+TEST_F(PONTest, VrfOutputCommittedProofExcludedFromHash) {
+    CBlockHeader base = MakeVrfHeader();
+    uint256 h0 = base.GetHash();
+
+    // The proof is excluded from the block hash (like the signature): changing it must NOT
+    // change the hash — required so CBlockIndex (which omits the proof) recomputes correctly.
+    CBlockHeader p = base;
+    p.nodesVrfProof = std::vector<unsigned char>(81, 0x11);
+    EXPECT_EQ(p.GetHash(), h0);
+
+    // The VRF output IS committed: changing it MUST change the hash (so it is signed/immutable
+    // and usable as the deterministic fork-choice key).
+    CBlockHeader o = base;
+    o.nodesVrfOutput = uint256S("0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+    EXPECT_NE(o.GetHash(), h0);
+}
+
+// --- Real ECVRF prove/verify path (the same crypto ContextualCheckPONBlockHeader runs) -
+
+TEST_F(PONTest, EcvrfProveVerifyRoundTrip) {
+    CKey key;
+    key.MakeNewKey(true);
+    CPubKey pub = key.GetPubKey();
+    uint256 seed = uint256S("0x1111111111111111111111111111111111111111111111111111111111111111");
+
+    std::vector<unsigned char> proof;
+    uint256 beta;
+    ASSERT_TRUE(ECVRF_Prove(key, pub, seed, proof, beta));
+    EXPECT_EQ(proof.size(), 81u);
+
+    // Verify against the same key+seed reproduces the output.
+    uint256 beta2;
+    EXPECT_TRUE(ECVRF_Verify(pub, seed, proof, beta2));
+    EXPECT_EQ(beta2, beta);
+
+    // Tampered proof is rejected.
+    std::vector<unsigned char> badProof = proof;
+    badProof[40] ^= 0x01;
+    uint256 bx;
+    EXPECT_FALSE(ECVRF_Verify(pub, seed, badProof, bx));
+
+    // Wrong seed is rejected (binds the output to the epoch seed).
+    uint256 by;
+    EXPECT_FALSE(ECVRF_Verify(pub, uint256S("0x99"), proof, by));
+
+    // Wrong key is rejected (binds the output to the operator key).
+    CKey other;
+    other.MakeNewKey(true);
+    uint256 bz;
+    EXPECT_FALSE(ECVRF_Verify(other.GetPubKey(), seed, proof, bz));
+
+    // Deterministic: proving again yields the identical proof+output (RFC 6979 nonce).
+    std::vector<unsigned char> proof2;
+    uint256 beta3;
+    ASSERT_TRUE(ECVRF_Prove(key, pub, seed, proof2, beta3));
+    EXPECT_EQ(proof2, proof);
+    EXPECT_EQ(beta3, beta);
 }

--- a/src/gtest/test_pon.cpp
+++ b/src/gtest/test_pon.cpp
@@ -7,8 +7,11 @@
 #include "chainparams.h"
 #include "consensus/params.h"
 #include "main.h"
+#include "pon/pon.h"
 #include "pon/pon-fork.h"
 #include "primitives/block.h"
+#include "chain.h"
+#include "uint256.h"
 #include "amount.h"
 
 // Define node tiers for testing (from fluxnode/fluxnode.h)
@@ -504,4 +507,47 @@ TEST_F(PONTest, POWBlockHeaderSerialization) {
     EXPECT_EQ(powBlock2.nBits, powBlock.nBits);
     EXPECT_EQ(powBlock2.nNonce, powBlock.nNonce);
     EXPECT_EQ(powBlock2.nSolution, powBlock.nSolution);
+}
+
+// --- PON-VRF deterministic fork choice (ComparePonForkChoice) -------------------------
+// This is the convergence guarantee: competing same-height VRF blocks must resolve to the
+// same winner on every node (lowest VRF output), regardless of arrival order.
+
+static CBlockIndex MakeVrfIndex(int height, const uint256& vrfOut) {
+    CBlockIndex idx;                       // SetNull() via default ctor
+    idx.nVersion = CBlockHeader::PON_VRF_VERSION;
+    idx.nHeight = height;
+    idx.nodesVrfOutput = vrfOut;
+    return idx;
+}
+
+TEST_F(PONTest, VrfForkChoiceLowestOutputWins) {
+    CBlockIndex a = MakeVrfIndex(100, uint256S("0x1111111111111111111111111111111111111111111111111111111111111111"));
+    CBlockIndex b = MakeVrfIndex(100, uint256S("0x2222222222222222222222222222222222222222222222222222222222222222"));
+
+    // Whichever output is lower by uint256 ordering must be preferred (negative result).
+    // (The exact ordering direction is irrelevant to convergence; determinism is.)
+    bool aLower = (a.nodesVrfOutput < b.nodesVrfOutput);
+    EXPECT_EQ(ComparePonForkChoice(&a, &b) < 0, aLower);
+    EXPECT_EQ(ComparePonForkChoice(&a, &b) > 0, !aLower);
+}
+
+TEST_F(PONTest, VrfForkChoiceAntisymmetricAndDeterministic) {
+    CBlockIndex a = MakeVrfIndex(100, uint256S("0x00000000000000000000000000000000000000000000000000000000000000aa"));
+    CBlockIndex b = MakeVrfIndex(100, uint256S("0x00000000000000000000000000000000000000000000000000000000000000bb"));
+
+    int ab = ComparePonForkChoice(&a, &b);
+    // Antisymmetry: swapping arguments flips the sign — so all nodes agree on the winner.
+    EXPECT_EQ(ab, -ComparePonForkChoice(&b, &a));
+    // Determinism: same inputs always give the same result.
+    EXPECT_EQ(ab, ComparePonForkChoice(&a, &b));
+    EXPECT_NE(ab, 0); // distinct outputs are decided, never a tie
+}
+
+TEST_F(PONTest, VrfForkChoiceEqualOutputUndecided) {
+    uint256 same = uint256S("0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+    CBlockIndex a = MakeVrfIndex(100, same);
+    CBlockIndex b = MakeVrfIndex(100, same);
+    // Identical VRF output -> no decision; caller falls back to first-seen.
+    EXPECT_EQ(ComparePonForkChoice(&a, &b), 0);
 }

--- a/src/gtest/test_pon.cpp
+++ b/src/gtest/test_pon.cpp
@@ -646,3 +646,46 @@ TEST_F(PONTest, EcvrfProveVerifyRoundTrip) {
     EXPECT_EQ(proof2, proof);
     EXPECT_EQ(beta3, beta);
 }
+
+TEST_F(PONTest, VrfMessagePerNodeUnderSharedOperatorKey) {
+    // Operator keys are shared across an owner's fleet in practice. The VRF message must
+    // therefore mix in the per-node collateral outpoint: with the key alone, N same-key
+    // nodes share one lottery draw and broadcast N identical-priority blocks on a win.
+    const Consensus::Params& params = Params().GetConsensus();
+
+    COutPoint collateralA(uint256S("0xaa"), 0);
+    COutPoint collateralB(uint256S("0xbb"), 0);
+    COutPoint collateralA1(uint256S("0xaa"), 1);
+
+    uint256 msgA = GetPonVrfMessage(NULL, 100, collateralA, params);
+    uint256 msgB = GetPonVrfMessage(NULL, 100, collateralB, params);
+    uint256 msgA1 = GetPonVrfMessage(NULL, 100, collateralA1, params);
+
+    // Distinct nodes (different txid OR different vout) get distinct messages.
+    EXPECT_NE(msgA, msgB);
+    EXPECT_NE(msgA, msgA1);
+
+    // Same node, same slot is deterministic; a new slot is a fresh draw.
+    EXPECT_EQ(msgA, GetPonVrfMessage(NULL, 100, collateralA, params));
+    EXPECT_NE(msgA, GetPonVrfMessage(NULL, 101, collateralA, params));
+
+    // Under ONE shared operator key, distinct messages yield independent VRF outputs,
+    // each verifiable against the same pubkey — restoring one draw per node.
+    CKey opKey;
+    opKey.MakeNewKey(true);
+    CPubKey opPub = opKey.GetPubKey();
+
+    std::vector<unsigned char> proofA, proofB;
+    uint256 yA, yB;
+    ASSERT_TRUE(ECVRF_Prove(opKey, opPub, msgA, proofA, yA));
+    ASSERT_TRUE(ECVRF_Prove(opKey, opPub, msgB, proofB, yB));
+    EXPECT_NE(yA, yB);
+
+    uint256 yCheck;
+    EXPECT_TRUE(ECVRF_Verify(opPub, msgA, proofA, yCheck));
+    EXPECT_EQ(yCheck, yA);
+
+    // A proof made for node A does not verify as node B (cross-node replay rejected).
+    uint256 yx;
+    EXPECT_FALSE(ECVRF_Verify(opPub, msgB, proofA, yx));
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5337,8 +5337,13 @@ bool CheckBlockHeader(
                              REJECT_INVALID, "bad-pon-sig-size");
 
         if (!IsEmergencyBlock((block))) {
-            // Check proof of work matches claimed amount
-            if (fCheckPOW && !CheckProofOfNode(GetPONHash(block), block.nBits, chainparams.GetConsensus()))
+            // Check proof of node matches claimed amount. For PON-VRF blocks the eligibility
+            // value is the committed VRF output (the full proof is verified contextually in
+            // ContextualCheckPONBlockHeader); for legacy PON blocks it is GetPONHash.
+            uint256 ponEligibilityValue = (block.nVersion >= CBlockHeader::PON_VRF_VERSION)
+                                              ? block.nodesVrfOutput
+                                              : GetPONHash(block);
+            if (fCheckPOW && !CheckProofOfNode(ponEligibilityValue, block.nBits, chainparams.GetConsensus()))
                 return state.DoS(50, error("CheckBlockHeader(): proof of node failed"),
                                  REJECT_INVALID, "high-hash");
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -159,25 +159,18 @@ namespace {
             bool isPONBlockB = (pb->nVersion >= CBlockHeader::PON_VERSION);
 
             if (isPONBlockA && isPONBlockB && pa->nHeight == pb->nHeight) {
-                // PON-VRF blocks: tie-break by VRF output (lowest wins). This is the
-                // consensus-level convergence rule for VRF leader election — the VRF
-                // output is un-grindable, so unlike GetPONHash (which depends on the
-                // proposer-chosen nTime/slot and could be ground to win ties) an attacker
-                // cannot bias which competing block wins. Falls back to GetPONHash when
-                // either block predates PON_VRF (mixed-version fork around activation).
-                bool isVrfA = (pa->nVersion >= CBlockHeader::PON_VRF_VERSION);
-                bool isVrfB = (pb->nVersion >= CBlockHeader::PON_VRF_VERSION);
-
-                uint256 scoreA = isVrfA ? pa->nodesVrfOutput : GetPONHash(pa->GetBlockHeader());
-                uint256 scoreB = isVrfB ? pb->nodesVrfOutput : GetPONHash(pb->GetBlockHeader());
-
-                if (scoreA < scoreB) {
-                    return false; // A has better (lower) score, A wins
+                // Deterministic PON tie-break (see ComparePonForkChoice): PON-VRF blocks
+                // compare by un-grindable VRF output, legacy PON blocks by GetPONHash.
+                // Every node computes the same winner regardless of arrival order, so the
+                // network converges instead of forking back and forth.
+                int cmp = ComparePonForkChoice(pa, pb);
+                if (cmp < 0) {
+                    return false; // A preferred (lower score), A wins
                 }
-                if (scoreA > scoreB) {
-                    return true;  // B has better (lower) score, B wins
+                if (cmp > 0) {
+                    return true;  // B preferred (lower score), B wins
                 }
-                // If scores are equal, fall through to sequence ID
+                // Undecided (equal scores): fall through to sequence ID
             }
 
             // ... then by earliest time received, ...

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2775,7 +2775,11 @@ bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, const Consensus:
               CheckProofOfWork(block.GetHash(), block.nBits, consensusParams)))
             return error("ReadBlockFromDisk: Errors in block header at %s", pos.ToString());
     } else {
-        if (!CheckProofOfNode(GetPONHash(block), block.nBits, consensusParams) && !IsEmergencyBlock(block)) {
+        // For PON-VRF blocks the eligibility value is the committed VRF output, not GetPONHash.
+        uint256 ponEligibilityValue = (block.nVersion >= CBlockHeader::PON_VRF_VERSION)
+                                          ? block.nodesVrfOutput
+                                          : GetPONHash(block);
+        if (!CheckProofOfNode(ponEligibilityValue, block.nBits, consensusParams) && !IsEmergencyBlock(block)) {
             return error("ReadBlockFromDisk: Errors in block header at %s", pos.ToString());
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -153,24 +153,31 @@ namespace {
             if (pa->nChainWork > pb->nChainWork) return false;
             if (pa->nChainWork < pb->nChainWork) return true;
 
-            // For PON blocks at same height (same chain work), use PON hash as deterministic tie-breaker
-            // This prevents network splits when multiple eligible nodes create competing blocks
-            // Lower PON hash wins (same ordering as our rank-based coordination)
-            bool isPONBlockA = (pa->nVersion >= 100);
-            bool isPONBlockB = (pb->nVersion >= 100);
+            // For PON blocks at same height (same chain work), use a deterministic
+            // tie-breaker so all nodes converge on the same block instead of splitting.
+            bool isPONBlockA = (pa->nVersion >= CBlockHeader::PON_VERSION);
+            bool isPONBlockB = (pb->nVersion >= CBlockHeader::PON_VERSION);
 
             if (isPONBlockA && isPONBlockB && pa->nHeight == pb->nHeight) {
-                // Both are PON blocks at same height - use PON hash as tie-breaker
-                uint256 ponHashA = GetPONHash(pa->GetBlockHeader());
-                uint256 ponHashB = GetPONHash(pb->GetBlockHeader());
+                // PON-VRF blocks: tie-break by VRF output (lowest wins). This is the
+                // consensus-level convergence rule for VRF leader election — the VRF
+                // output is un-grindable, so unlike GetPONHash (which depends on the
+                // proposer-chosen nTime/slot and could be ground to win ties) an attacker
+                // cannot bias which competing block wins. Falls back to GetPONHash when
+                // either block predates PON_VRF (mixed-version fork around activation).
+                bool isVrfA = (pa->nVersion >= CBlockHeader::PON_VRF_VERSION);
+                bool isVrfB = (pb->nVersion >= CBlockHeader::PON_VRF_VERSION);
 
-                if (ponHashA < ponHashB) {
-                    return false; // A has better (lower) hash, A wins
+                uint256 scoreA = isVrfA ? pa->nodesVrfOutput : GetPONHash(pa->GetBlockHeader());
+                uint256 scoreB = isVrfB ? pb->nodesVrfOutput : GetPONHash(pb->GetBlockHeader());
+
+                if (scoreA < scoreB) {
+                    return false; // A has better (lower) score, A wins
                 }
-                if (ponHashA > ponHashB) {
-                    return true;  // B has better (lower) hash, B wins
+                if (scoreA > scoreB) {
+                    return true;  // B has better (lower) score, B wins
                 }
-                // If hashes are equal, fall through to sequence ID
+                // If scores are equal, fall through to sequence ID
             }
 
             // ... then by earliest time received, ...

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -577,7 +577,7 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
         if (pblock->nVersion >= CBlockHeader::PON_VRF_VERSION) {
             int64_t genesisTimestamp = chainparams.GenesisBlock().nTime;
             uint32_t vrfSlot = GetSlotNumber(pblock->nTime, genesisTimestamp, chainparams.GetConsensus());
-            uint256 seed = GetPonVrfMessage(pindexPrev, vrfSlot, chainparams.GetConsensus());
+            uint256 seed = GetPonVrfMessage(pindexPrev, vrfSlot, pblock->nodesCollateral, chainparams.GetConsensus());
             std::vector<unsigned char> vrfProof;
             uint256 vrfOut;
             CKey vk; CPubKey vpub; std::string verr;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -575,7 +575,9 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
         // TestBlockValidity below and before the block is signed). The minter computes the
         // same values from the same operator key + epoch seed (deterministic).
         if (pblock->nVersion >= CBlockHeader::PON_VRF_VERSION) {
-            uint256 seed = GetEpochSeed(pindexPrev, chainparams.GetConsensus());
+            int64_t genesisTimestamp = chainparams.GenesisBlock().nTime;
+            uint32_t vrfSlot = GetSlotNumber(pblock->nTime, genesisTimestamp, chainparams.GetConsensus());
+            uint256 seed = GetPonVrfMessage(pindexPrev, vrfSlot, chainparams.GetConsensus());
             std::vector<unsigned char> vrfProof;
             uint256 vrfOut;
             CKey vk; CPubKey vpub; std::string verr;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -36,6 +36,8 @@
 #include "validationinterface.h"
 #include "pon/pon-fork.h"
 #include "pon/pon.h"
+#include "crypto/ecvrf.h"
+#include "fluxnode/obfuscation.h"
 
 #include "sodium.h"
 
@@ -544,9 +546,11 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
 
         // Fill in header
         if (IsPONActive(pindexPrev->nHeight + 1)) {
-            pblock->nVersion = CBlockHeader::PON_VERSION;
+            pblock->nVersion = IsPONVRFActive(pindexPrev->nHeight + 1)
+                                   ? CBlockHeader::PON_VRF_VERSION
+                                   : CBlockHeader::PON_VERSION;
             pblock->nodesCollateral = ponNodeCollateral;
-            
+
             // For PON blocks, use enforced time if provided
             if (enforceTime > 0) {
                 pblock->nTime = enforceTime;
@@ -565,6 +569,32 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
         pblock->nBits = GetNextWorkRequiredByFork(pindexPrev, pblock, chainparams.GetConsensus());
         pblock->nSolution.clear();
         pblocktemplate->vTxSigOps[0] = GetLegacySigOpCount(pblock->vtx[0]);
+
+        // PON-VRF: populate the VRF output/proof so the assembled block is a valid v101
+        // block (committed VRF output is in the block hash, so this must happen before
+        // TestBlockValidity below and before the block is signed). The minter computes the
+        // same values from the same operator key + epoch seed (deterministic).
+        if (pblock->nVersion >= CBlockHeader::PON_VRF_VERSION) {
+            uint256 seed = GetEpochSeed(pindexPrev, chainparams.GetConsensus());
+            std::vector<unsigned char> vrfProof;
+            uint256 vrfOut;
+            CKey vk; CPubKey vpub; std::string verr;
+            if (!strFluxnodePrivKey.empty() &&
+                obfuScationSigner.SetKey(strFluxnodePrivKey, verr, vk, vpub) &&
+                ECVRF_Prove(vk, vpub, seed, vrfProof, vrfOut)) {
+                pblock->nodesVrfOutput = vrfOut;
+                pblock->nodesVrfProof = vrfProof;
+            } else {
+                // No operator key available (e.g. regtest generate without -zelnodeprivkey):
+                // deterministic placeholder output + dummy proof. The proof is not verified on
+                // regtest; on mainnet/testnet the minter always has a key so this branch is
+                // unused. Derived from the seed only (caller may set a real proof afterwards).
+                CHashWriter ss(SER_GETHASH, 0);
+                ss << seed << pblock->nodesCollateral;
+                pblock->nodesVrfOutput = ss.GetHash();
+                pblock->nodesVrfProof = std::vector<unsigned char>(81, 0);
+            }
+        }
 
         if (fForEmergency) {
             return pblocktemplate.release();

--- a/src/pon/pon-fork.cpp
+++ b/src/pon/pon-fork.cpp
@@ -5,6 +5,7 @@
 #include "pon-fork.h"
 #include "../chain.h"
 #include "../chainparams.h"
+#include "../consensus/upgrades.h"
 #include "../consensus/validation.h"
 #include "../pow.h"
 #include "../util.h"
@@ -13,10 +14,16 @@
 bool IsPONActive(int nHeight)
 {
     int ponActivationHeight = GetPONActivationHeight();
-    
+
     // PON is active if we're at or past the activation height
     // and activation height is set (not NO_ACTIVATION_HEIGHT)
     return nHeight >= ponActivationHeight;
+}
+
+bool IsPONVRFActive(int nHeight)
+{
+    // VRF leader election: active at/after the UPGRADE_PON_VRF activation height.
+    return NetworkUpgradeActive(nHeight, Params().GetConsensus(), Consensus::UPGRADE_PON_VRF);
 }
 
 unsigned int GetNextWorkRequiredByFork(const CBlockIndex* pindexLast,

--- a/src/pon/pon-fork.h
+++ b/src/pon/pon-fork.h
@@ -17,6 +17,9 @@ class CValidationState;
 // Check if PON is activated at a given height (hard cutoff)
 bool IsPONActive(int nHeight);
 
+// Check if PON VRF leader election is activated at a given height
+bool IsPONVRFActive(int nHeight);
+
 // Get the next work required based on POW or PON (switches at activation)
 unsigned int GetNextWorkRequiredByFork(const CBlockIndex* pindexLast, 
                                        const CBlockHeader* pblock,

--- a/src/pon/pon-minter.cpp
+++ b/src/pon/pon-minter.cpp
@@ -4,6 +4,7 @@
 
 #include "pon-minter.h"
 #include "../arith_uint256.h"
+#include "../crypto/ecvrf.h"
 #include "../miner.h"
 #include "pon.h"
 #include "pon-fork.h"
@@ -219,39 +220,78 @@ void PONMinter(const CChainParams& chainparams)
             // - Ranking simply helps nodes agree on who should try first
             // - Lower-ranked nodes wait longer, see higher-ranked blocks, and skip
             // - This dramatically reduces orphan blocks and network waste
-            std::vector<EligibleNodeInfo> eligibleNodes = GetEligibleNodes(pindexPrev, currentSlot, nBits);
+            // Eligibility + a self-computable minting-priority delay.
+            // VRF path produces the proof/output that will be committed to the block.
+            std::vector<unsigned char> vrfProof;
+            uint256 vrfOutput;
+            int myRank = 1;  // legacy rank; VRF path encodes priority in the delay instead
+            const bool usingVrf = IsPONVRFActive(pindexPrev->nHeight + 1);
 
-            // Find our rank in the eligible list
-            int myRank = GetNodeRank(eligibleNodes, collateral);
+            if (usingVrf) {
+                // VRF leader election: a node can compute only its OWN eligibility (other
+                // nodes' VRF outputs are unknowable without their secret keys). Coordination
+                // therefore uses a self-computable priority: lower VRF output => shorter delay
+                // (Algorand-style). Lower-priority nodes wait, see the higher-priority block,
+                // and skip — preserving the orphan-reduction property without a global ranking.
+                CKey opKey; CPubKey opPub; std::string keyErr;
+                if (!obfuScationSigner.SetKey(strFluxnodePrivKey, keyErr, opKey, opPub)) {
+                    LogPrintf("PON: No valid fluxnode key for VRF: %s\n", keyErr);
+                    lastAttemptedSlot = currentSlot;
+                    continue;
+                }
+                uint256 seed = GetEpochSeed(pindexPrev, consensusParams);
+                if (!ECVRF_Prove(opKey, opPub, seed, vrfProof, vrfOutput)) {
+                    LogPrintf("PON: VRF prove failed\n");
+                    lastAttemptedSlot = currentSlot;
+                    continue;
+                }
+                arith_uint256 tgt; tgt.SetCompact(nBits);
+                if (UintToArith256(vrfOutput) > tgt) {
+                    LogPrint("pon", "PON: Not VRF-eligible for slot %d (y=%s target=%s)\n",
+                             currentSlot, vrfOutput.GetHex(), tgt.GetHex());
+                    lastAttemptedSlot = currentSlot;
+                    continue;
+                }
+                // Map y in [0, target] to a delay in [0, window]: lowest y mints first.
+                arith_uint256 denom = tgt >> 16;
+                if (denom == 0) denom = arith_uint256(1);
+                uint64_t frac16 = (UintToArith256(vrfOutput) / denom).GetLow64();
+                if (frac16 > 65535) frac16 = 65535;
+                int rankDelayMs = (int)((int64_t)24000 * (int64_t)frac16 / 65536);
+                LogPrintf("PON: VRF-eligible for slot %d (y=%s) - waiting %dms before minting\n",
+                         currentSlot, vrfOutput.GetHex(), rankDelayMs);
+                MilliSleep(rankDelayMs);
+            } else {
+                std::vector<EligibleNodeInfo> eligibleNodes = GetEligibleNodes(pindexPrev, currentSlot, nBits);
 
-            if (myRank == -1) {
-                // Not eligible for this slot
-                arith_uint256 target;
-                target.SetCompact(nBits);
-                uint256 ponHash = GetPONHash(collateral, pindexPrev->GetBlockHash(), currentSlot);
-                LogPrint("pon", "PON: Not eligible for slot %d - hash=%s target=%s (nBits=%08x)\n",
-                         currentSlot, ponHash.GetHex(), target.GetHex(), nBits);
-                lastAttemptedSlot = currentSlot;
-                continue;
+                // Find our rank in the eligible list
+                myRank = GetNodeRank(eligibleNodes, collateral);
+
+                if (myRank == -1) {
+                    // Not eligible for this slot
+                    arith_uint256 target;
+                    target.SetCompact(nBits);
+                    uint256 ponHash = GetPONHash(collateral, pindexPrev->GetBlockHash(), currentSlot);
+                    LogPrint("pon", "PON: Not eligible for slot %d - hash=%s target=%s (nBits=%08x)\n",
+                             currentSlot, ponHash.GetHex(), target.GetHex(), nBits);
+                    lastAttemptedSlot = currentSlot;
+                    continue;
+                }
+
+                // Log eligibility with rank information
+                int totalEligible = eligibleNodes.size();
+                uint256 myHash = eligibleNodes[myRank - 1].ponHash;
+                LogPrintf("PON: Eligible for slot %d - Rank %d of %d eligible nodes (hash: %s)\n",
+                         currentSlot, myRank, totalEligible, myHash.GetHex());
+
+                // Rank-based delay to coordinate block production across 30-second slot window
+                // Rank 1 = 4s, Rank 2 = 8s, ... With 4s intervals, we fit 7 ranks in a 30s slot window
+                int rankDelayMs = myRank * 4000; // 4 second intervals
+
+                LogPrintf("PON: Rank %d of %d eligible - waiting %dms (%.1fs) before minting\n",
+                         myRank, totalEligible, rankDelayMs, rankDelayMs / 1000.0);
+                MilliSleep(rankDelayMs);
             }
-
-            // Log eligibility with rank information
-            int totalEligible = eligibleNodes.size();
-            uint256 myHash = eligibleNodes[myRank - 1].ponHash;
-            LogPrintf("PON: Eligible for slot %d - Rank %d of %d eligible nodes (hash: %s)\n",
-                     currentSlot, myRank, totalEligible, myHash.GetHex());
-
-            // Rank-based delay to coordinate block production across 30-second slot window
-            // Account for block propagation time (typically 2-5 seconds)
-            // Rank 1 waits 4s to allow any late blocks from previous slot to propagate
-            // Each subsequent rank waits 4 more seconds, giving time for higher-ranked blocks to propagate
-            // Example: Rank 1 = 4s, Rank 2 = 8s, Rank 3 = 12s, Rank 4 = 16s, Rank 5 = 20s, Rank 6 = 24s, Rank 7 = 28s
-            // With 4s intervals, we fit 7 ranks in a 30s slot window
-            int rankDelayMs = myRank * 4000; // 4 second intervals
-
-            LogPrintf("PON: Rank %d of %d eligible - waiting %dms (%.1fs) before minting\n",
-                     myRank, totalEligible, rankDelayMs, rankDelayMs / 1000.0);
-            MilliSleep(rankDelayMs);
 
             // Get fresh timestamp after rank delay completes
             // This ensures block timestamps reflect when they were actually created,
@@ -320,6 +360,15 @@ void PONMinter(const CChainParams& chainparams)
             }
 
             CBlock* pblock = &pblocktemplate->block;
+
+            // PON-VRF: commit the VRF output + proof to the block before signing. These are
+            // included under SER_GETHASH, so the signature covers them. The eligibility proof
+            // was computed above over the (un-grindable) epoch seed.
+            if (usingVrf) {
+                pblock->nVersion = CBlockHeader::PON_VRF_VERSION;
+                pblock->nodesVrfOutput = vrfOutput;
+                pblock->nodesVrfProof = vrfProof;
+            }
 
             // Sign the block with our fluxnode private key
             // Block signature proves we control the collateral used for PON eligibility

--- a/src/pon/pon-minter.cpp
+++ b/src/pon/pon-minter.cpp
@@ -239,7 +239,7 @@ void PONMinter(const CChainParams& chainparams)
                     lastAttemptedSlot = currentSlot;
                     continue;
                 }
-                uint256 seed = GetEpochSeed(pindexPrev, consensusParams);
+                uint256 seed = GetPonVrfMessage(pindexPrev, currentSlot, consensusParams);
                 if (!ECVRF_Prove(opKey, opPub, seed, vrfProof, vrfOutput)) {
                     LogPrintf("PON: VRF prove failed\n");
                     lastAttemptedSlot = currentSlot;

--- a/src/pon/pon-minter.cpp
+++ b/src/pon/pon-minter.cpp
@@ -239,7 +239,7 @@ void PONMinter(const CChainParams& chainparams)
                     lastAttemptedSlot = currentSlot;
                     continue;
                 }
-                uint256 seed = GetPonVrfMessage(pindexPrev, currentSlot, consensusParams);
+                uint256 seed = GetPonVrfMessage(pindexPrev, currentSlot, collateral, consensusParams);
                 if (!ECVRF_Prove(opKey, opPub, seed, vrfProof, vrfOutput)) {
                     LogPrintf("PON: VRF prove failed\n");
                     lastAttemptedSlot = currentSlot;

--- a/src/pon/pon.cpp
+++ b/src/pon/pon.cpp
@@ -434,6 +434,13 @@ void LogPONEligibility(const CBlockIndex* pindexPrev, int slotOffset)
         return; // PON not active yet
     }
 
+    // Under VRF leader election the legacy GetPONHash formula below is dead, and other
+    // nodes' eligibility cannot be computed at all (each draw needs that node's secret
+    // key) — anything this function printed would be meaningless for operators.
+    if (IsPONVRFActive(pindexPrev->nHeight + 1)) {
+        return;
+    }
+
     // Start timing
     int64_t nTimeStart = GetTimeMicros();
 

--- a/src/pon/pon.cpp
+++ b/src/pon/pon.cpp
@@ -123,12 +123,18 @@ uint256 GetEpochSeed(const CBlockIndex* pindexPrev, const Consensus::Params& par
 // rotates and the chain stays live (without this, a node is eligible for either every slot
 // or no slot in an epoch). The slot (from nTime) carries only the minor ~10-slot future-time
 // grind already acknowledged in the design — the large prevBlockHash/coinbase grind is gone.
-uint256 GetPonVrfMessage(const CBlockIndex* pindexPrev, uint32_t slot, const Consensus::Params& params)
+// Mixing in the collateral outpoint makes the draw per-node under shared operator keys
+// (standard fleet practice): without it, N same-key nodes share ONE draw (1/N rewards) and
+// on a win all N broadcast at the identical VRF-derived delay, with identical outputs that
+// also void the lowest-VRF fork-choice tie-break. The outpoint is fixed at node registration
+// — before any future epoch seed exists — so it adds no grinding surface.
+uint256 GetPonVrfMessage(const CBlockIndex* pindexPrev, uint32_t slot, const COutPoint& collateral, const Consensus::Params& params)
 {
     uint256 epochSeed = GetEpochSeed(pindexPrev, params);
     CHashWriter ss(SER_GETHASH, 0);
     ss << epochSeed;
     ss << slot;
+    ss << collateral;
     return ss.GetHash();
 }
 
@@ -397,7 +403,7 @@ bool ContextualCheckPONBlockHeader(const CBlockHeader& block, const CBlockIndex*
         if (IsPONVRFActive(currentHeight)) {
             int64_t genesisTimestamp = Params().GenesisBlock().nTime;
             uint32_t slot = GetSlotNumber(block.nTime, genesisTimestamp, Params().GetConsensus());
-            uint256 seed = GetPonVrfMessage(pindexPrev, slot, params);
+            uint256 seed = GetPonVrfMessage(pindexPrev, slot, block.nodesCollateral, params);
             uint256 betaComputed;
             if (!ECVRF_Verify(data.pubKey, seed, block.nodesVrfProof, betaComputed)) {
                 // Proof depends on chain-state (seed) and the cache; treat like a signature

--- a/src/pon/pon.cpp
+++ b/src/pon/pon.cpp
@@ -220,6 +220,22 @@ unsigned int GetNextPONWorkRequired(const CBlockIndex* pindexLast)
     return newTarget.GetCompact();
 }
 
+int ComparePonForkChoice(const CBlockIndex* a, const CBlockIndex* b)
+{
+    // VRF blocks: compare by the committed VRF output (un-grindable). Legacy PON
+    // blocks: by GetPONHash. A VRF and a legacy block (mixed-version fork around
+    // activation) each use their own score; lower wins in all cases.
+    bool vrfA = (a->nVersion >= CBlockHeader::PON_VRF_VERSION);
+    bool vrfB = (b->nVersion >= CBlockHeader::PON_VRF_VERSION);
+
+    uint256 scoreA = vrfA ? a->nodesVrfOutput : GetPONHash(a->GetBlockHeader());
+    uint256 scoreB = vrfB ? b->nodesVrfOutput : GetPONHash(b->GetBlockHeader());
+
+    if (scoreA < scoreB) return -1;  // a preferred
+    if (scoreA > scoreB) return 1;   // b preferred
+    return 0;                         // undecided -> caller falls back to first-seen
+}
+
 bool CheckPONBlockHeader(const CBlockHeader& block, const CBlockIndex* pindexPrev,
                             const Consensus::Params& params)
 {

--- a/src/pon/pon.cpp
+++ b/src/pon/pon.cpp
@@ -118,6 +118,20 @@ uint256 GetEpochSeed(const CBlockIndex* pindexPrev, const Consensus::Params& par
     return ss.GetHash();
 }
 
+// PON-VRF per-slot eligibility input. The epoch seed (un-grindable) provides the base
+// randomness; mixing in the slot makes eligibility a FRESH draw each slot, so leadership
+// rotates and the chain stays live (without this, a node is eligible for either every slot
+// or no slot in an epoch). The slot (from nTime) carries only the minor ~10-slot future-time
+// grind already acknowledged in the design — the large prevBlockHash/coinbase grind is gone.
+uint256 GetPonVrfMessage(const CBlockIndex* pindexPrev, uint32_t slot, const Consensus::Params& params)
+{
+    uint256 epochSeed = GetEpochSeed(pindexPrev, params);
+    CHashWriter ss(SER_GETHASH, 0);
+    ss << epochSeed;
+    ss << slot;
+    return ss.GetHash();
+}
+
 unsigned int GetNextPONWorkRequired(const CBlockIndex* pindexLast)
 {
     const Consensus::Params& params = Params().GetConsensus();
@@ -381,7 +395,9 @@ bool ContextualCheckPONBlockHeader(const CBlockHeader& block, const CBlockIndex*
         // operator key and the (un-grindable) epoch seed. Shares the deferral logic above:
         // we only reach here when the cache state is correct for this block.
         if (IsPONVRFActive(currentHeight)) {
-            uint256 seed = GetEpochSeed(pindexPrev, params);
+            int64_t genesisTimestamp = Params().GenesisBlock().nTime;
+            uint32_t slot = GetSlotNumber(block.nTime, genesisTimestamp, Params().GetConsensus());
+            uint256 seed = GetPonVrfMessage(pindexPrev, slot, params);
             uint256 betaComputed;
             if (!ECVRF_Verify(data.pubKey, seed, block.nodesVrfProof, betaComputed)) {
                 // Proof depends on chain-state (seed) and the cache; treat like a signature

--- a/src/pon/pon.cpp
+++ b/src/pon/pon.cpp
@@ -5,6 +5,7 @@
 #include "pon.h"
 #include "pon-fork.h"
 #include "../arith_uint256.h"
+#include "../crypto/ecvrf.h"
 #include "../chain.h"
 #include "../chainparams.h"
 #include "../emergencyblock.h"
@@ -90,6 +91,31 @@ uint32_t GetSlotNumber(int64_t timestamp, int64_t genesisTimestamp, const Consen
     // Calculate slot number based on time elapsed since genesis
     int64_t timeSinceGenesis = timestamp - genesisTimestamp;
     return static_cast<uint32_t>(timeSinceGenesis / params.nPonTargetSpacing);
+}
+
+// PON-VRF epoch seed. The randomness for a block's VRF eligibility is derived from a
+// window of blocks buried beyond the reorg horizon, so the proposer of the current block
+// cannot have authored (and therefore cannot grind) the seed. Constant for an entire epoch.
+static const int PON_VRF_EPOCH_LEN = 60;   // blocks per epoch (~30 min at 30s spacing)
+static const int PON_VRF_SEED_BURY = 60;   // window end is buried this many blocks (> MAX_REORG_LENGTH=40)
+
+uint256 GetEpochSeed(const CBlockIndex* pindexPrev, const Consensus::Params& params)
+{
+    int nHeight = pindexPrev ? pindexPrev->nHeight + 1 : 0;
+    int epoch = nHeight / PON_VRF_EPOCH_LEN;
+    int windowEnd = epoch * PON_VRF_EPOCH_LEN - PON_VRF_SEED_BURY;
+
+    // Genesis warmup: before a buried window exists, use a fixed bootstrap seed.
+    if (windowEnd < PON_VRF_EPOCH_LEN || pindexPrev == NULL) {
+        return Params().GenesisBlock().GetHash();
+    }
+
+    CHashWriter ss(SER_GETHASH, 0);
+    const CBlockIndex* p = pindexPrev->GetAncestor(windowEnd);
+    for (int i = 0; i < PON_VRF_EPOCH_LEN && p != NULL; ++i, p = p->pprev) {
+        ss << p->GetBlockHash();
+    }
+    return ss.GetHash();
 }
 
 unsigned int GetNextPONWorkRequired(const CBlockIndex* pindexLast)
@@ -208,7 +234,21 @@ bool CheckPONBlockHeader(const CBlockHeader& block, const CBlockIndex* pindexPre
 
     int nHeight = pindexPrev ? pindexPrev->nHeight + 1 : 0;
 
-    if (!CheckProofOfNode(GetPONHash(block), block.nBits, Params().GetConsensus(), nHeight)) {
+    if (IsPONVRFActive(nHeight)) {
+        // VRF leader election: eligibility is y <= target, where y = nodesVrfOutput.
+        // The proof that y is genuinely VRF(operator_key, epoch_seed) is verified
+        // contextually (ContextualCheckPONBlockHeader), where the operator pubkey is
+        // available; here we enforce the cheap, context-free preconditions.
+        if (block.nVersion < CBlockHeader::PON_VRF_VERSION) {
+            return error("CheckPONBlockHeader: block version %d below PON_VRF_VERSION", block.nVersion);
+        }
+        if (block.nodesVrfProof.size() != 81) {
+            return error("CheckPONBlockHeader: bad VRF proof size %d", (int)block.nodesVrfProof.size());
+        }
+        if (!CheckProofOfNode(block.nodesVrfOutput, block.nBits, Params().GetConsensus(), nHeight)) {
+            return error("CheckPONBlockHeader: VRF output doesn't meet target");
+        }
+    } else if (!CheckProofOfNode(GetPONHash(block), block.nBits, Params().GetConsensus(), nHeight)) {
         int64_t genesisTimestamp = Params().GenesisBlock().nTime;
         uint32_t slot = GetSlotNumber(block.nTime, genesisTimestamp, Params().GetConsensus());
         return error("CheckPONBlockHeader: stake hash doesn't meet target for slot %d", slot);
@@ -320,6 +360,28 @@ bool ContextualCheckPONBlockHeader(const CBlockHeader& block, const CBlockIndex*
 
         LogPrint("pon", "ContextualCheckPONBlockHeader: Signature verified for fluxnode %s (tier=%d)\n",
              block.nodesCollateral.ToString(), data.nTier);
+
+        // VRF leader election: verify the proof binds nodesVrfOutput to this fluxnode's
+        // operator key and the (un-grindable) epoch seed. Shares the deferral logic above:
+        // we only reach here when the cache state is correct for this block.
+        if (IsPONVRFActive(currentHeight)) {
+            uint256 seed = GetEpochSeed(pindexPrev, params);
+            uint256 betaComputed;
+            if (!ECVRF_Verify(data.pubKey, seed, block.nodesVrfProof, betaComputed)) {
+                // Proof depends on chain-state (seed) and the cache; treat like a signature
+                // failure (not permanently invalidating) to be safe under competing-chain validation.
+                fSignatureFailure = true;
+                return error("ContextualCheckPONBlockHeader: VRF proof verification failed for fluxnode %s (block=%s)",
+                            block.nodesCollateral.ToString(), block.GetHash().GetHex());
+            }
+            if (betaComputed != block.nodesVrfOutput) {
+                fSignatureFailure = true;
+                return error("ContextualCheckPONBlockHeader: VRF output mismatch for fluxnode %s (block=%s)",
+                            block.nodesCollateral.ToString(), block.GetHash().GetHex());
+            }
+            LogPrint("pon", "ContextualCheckPONBlockHeader: VRF proof verified for fluxnode %s\n",
+                 block.nodesCollateral.ToString());
+        }
     }
 
     LogPrint("pon", "ContextualCheckPONBlockHeader: Full validation passed for block %s\n", block.GetHash().GetHex());

--- a/src/pon/pon.h
+++ b/src/pon/pon.h
@@ -26,6 +26,10 @@ uint256 GetPONHash(const COutPoint& collateral, const uint256& prevBlockHash, ui
 // Calculate the slot number for a given timestamp relative to genesis
 uint32_t GetSlotNumber(int64_t timestamp, int64_t genesisTimestamp, const Consensus::Params& params);
 
+// PON-VRF: epoch seed (randomness) for VRF eligibility — derived from a buried block
+// window the current proposer did not author, so it is not grindable.
+uint256 GetEpochSeed(const CBlockIndex* pindexPrev, const Consensus::Params& params);
+
 // Get next PON work required (difficulty adjustment)
 unsigned int GetNextPONWorkRequired(const CBlockIndex* pindexLast);
 

--- a/src/pon/pon.h
+++ b/src/pon/pon.h
@@ -30,6 +30,11 @@ uint32_t GetSlotNumber(int64_t timestamp, int64_t genesisTimestamp, const Consen
 // window the current proposer did not author, so it is not grindable.
 uint256 GetEpochSeed(const CBlockIndex* pindexPrev, const Consensus::Params& params);
 
+// PON-VRF: per-slot VRF input = H(epoch_seed || slot). Mixing the slot gives a fresh
+// eligibility draw each slot (leader rotation / liveness). Used by both the minter and
+// ContextualCheckPONBlockHeader so prover and verifier agree.
+uint256 GetPonVrfMessage(const CBlockIndex* pindexPrev, uint32_t slot, const Consensus::Params& params);
+
 // PON fork-choice tie-break between two competing same-work/same-height PON blocks.
 // Returns <0 if a is preferred (wins the tie), >0 if b is preferred, 0 if undecided
 // (caller falls back to first-seen). PON-VRF blocks compare by VRF output (un-grindable);

--- a/src/pon/pon.h
+++ b/src/pon/pon.h
@@ -30,6 +30,12 @@ uint32_t GetSlotNumber(int64_t timestamp, int64_t genesisTimestamp, const Consen
 // window the current proposer did not author, so it is not grindable.
 uint256 GetEpochSeed(const CBlockIndex* pindexPrev, const Consensus::Params& params);
 
+// PON fork-choice tie-break between two competing same-work/same-height PON blocks.
+// Returns <0 if a is preferred (wins the tie), >0 if b is preferred, 0 if undecided
+// (caller falls back to first-seen). PON-VRF blocks compare by VRF output (un-grindable);
+// legacy PON blocks by GetPONHash. Lower value wins in both cases.
+int ComparePonForkChoice(const CBlockIndex* a, const CBlockIndex* b);
+
 // Get next PON work required (difficulty adjustment)
 unsigned int GetNextPONWorkRequired(const CBlockIndex* pindexLast);
 

--- a/src/pon/pon.h
+++ b/src/pon/pon.h
@@ -30,10 +30,14 @@ uint32_t GetSlotNumber(int64_t timestamp, int64_t genesisTimestamp, const Consen
 // window the current proposer did not author, so it is not grindable.
 uint256 GetEpochSeed(const CBlockIndex* pindexPrev, const Consensus::Params& params);
 
-// PON-VRF: per-slot VRF input = H(epoch_seed || slot). Mixing the slot gives a fresh
-// eligibility draw each slot (leader rotation / liveness). Used by both the minter and
-// ContextualCheckPONBlockHeader so prover and verifier agree.
-uint256 GetPonVrfMessage(const CBlockIndex* pindexPrev, uint32_t slot, const Consensus::Params& params);
+// PON-VRF: per-slot VRF input = H(epoch_seed || slot || collateral). Mixing the slot gives
+// a fresh eligibility draw each slot (leader rotation / liveness). Mixing the collateral
+// outpoint makes the draw per-NODE: operator keys are shared across an owner's fleet in
+// practice, and with a shared key alone every node computes the identical VRF output —
+// collapsing N nodes to one lottery draw and broadcasting N identical-priority blocks on a
+// win. Used by both the minter and ContextualCheckPONBlockHeader so prover and verifier
+// agree (the header already commits the outpoint as nodesCollateral).
+uint256 GetPonVrfMessage(const CBlockIndex* pindexPrev, uint32_t slot, const COutPoint& collateral, const Consensus::Params& params);
 
 // PON fork-choice tie-break between two competing same-work/same-height PON blocks.
 // Returns <0 if a is preferred (wins the tie), >0 if b is preferred, 0 if undecided

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -29,6 +29,7 @@ public:
     static const int32_t CURRENT_VERSION=4;
     // PON blocks use version 100 - high enough that POW miners won't accidentally use it
     static const int32_t PON_VERSION = 100;
+    static const int32_t PON_VRF_VERSION = 101;   // PON + VRF leader election (anti-grind)
     int32_t nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;
@@ -43,6 +44,9 @@ public:
     // PON fields (version >= 100)
     COutPoint nodesCollateral;     // The UTXO used as collateral
     std::vector<unsigned char> vchBlockSig;  // Signature proving ownership
+    // PON-VRF fields (version >= PON_VRF_VERSION): ECVRF-SECP256K1-SHA256-TAI
+    uint256 nodesVrfOutput;                   // y: VRF lottery value, compared to target
+    std::vector<unsigned char> nodesVrfProof; // pi: 81-byte VRF proof
 
     CBlockHeader()
     {
@@ -64,7 +68,16 @@ public:
         if (nVersion >= PON_VERSION) {
             // PON block
             READWRITE(nodesCollateral);
-            
+
+            // PON-VRF: the VRF output and proof are committed to the block hash
+            // (included under SER_GETHASH, unlike vchBlockSig). The VRF output is
+            // deterministic given (operator key, epoch seed), so committing it is
+            // not grindable.
+            if (nVersion >= PON_VRF_VERSION) {
+                READWRITE(nodesVrfOutput);
+                READWRITE(nodesVrfProof);
+            }
+
             // Exclude signature when computing hash for signing (SER_GETHASH)
             // This prevents circular dependency when signing the block
             if (!(s.GetType() & SER_GETHASH)) {
@@ -89,6 +102,8 @@ public:
         nSolution.clear();
         nodesCollateral.SetNull();
         vchBlockSig.clear();
+        nodesVrfOutput.SetNull();
+        nodesVrfProof.clear();
     }
     
     // Helper functions for PON

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -69,18 +69,20 @@ public:
             // PON block
             READWRITE(nodesCollateral);
 
-            // PON-VRF: the VRF output and proof are committed to the block hash
-            // (included under SER_GETHASH, unlike vchBlockSig). The VRF output is
-            // deterministic given (operator key, epoch seed), so committing it is
-            // not grindable.
+            // PON-VRF: the VRF OUTPUT (y) is committed to the block hash (and so is
+            // signed and immutable). y is deterministic given (operator key, epoch seed),
+            // so committing it is not grindable. It is also the deterministic fork-choice
+            // tie-breaker (lowest y wins), so CBlockIndex stores it.
             if (nVersion >= PON_VRF_VERSION) {
                 READWRITE(nodesVrfOutput);
-                READWRITE(nodesVrfProof);
             }
 
-            // Exclude signature when computing hash for signing (SER_GETHASH)
-            // This prevents circular dependency when signing the block
+            // Excluded from the block hash (like the signature, below): the VRF proof is
+            // self-validating against the committed output, so it need not be committed.
             if (!(s.GetType() & SER_GETHASH)) {
+                if (nVersion >= PON_VRF_VERSION) {
+                    READWRITE(nodesVrfProof);
+                }
                 READWRITE(vchBlockSig);
             }
         } else {

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -255,6 +255,13 @@ public:
             // PON block - include all data (already compact)
             READWRITE(nodesCollateral);
             READWRITE(vchBlockSig);
+            // PON-VRF: the VRF output is committed to the block hash, so it MUST be carried
+            // here or the receiver recomputes the wrong hash (-> "non-continuous cmpheaders").
+            // The proof is included too, mirroring vchBlockSig (full header data).
+            if (nVersion >= PON_VRF_VERSION) {
+                READWRITE(nodesVrfOutput);
+                READWRITE(nodesVrfProof);
+            }
         } else {
             // POW block - include nNonce but OMIT nSolution
             // The large Equihash solution is not needed for checkpointed blocks

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -22,6 +22,9 @@
 #include "pon/pon.h"
 #include "pon/pon-fork.h"
 #include "pon/pon-minter.h"
+#include "crypto/ecvrf.h"
+#include "fluxnode/obfuscation.h"
+#include "hash.h"
 #include "net.h"
 #include "pow.h"
 #include "rpc/server.h"
@@ -253,6 +256,9 @@ UniValue generate(const UniValue& params, bool fHelp)
         }
 
         if (isPONActive) {
+            // PON-VRF block fields (v101 + VRF output/proof) are populated inside
+            // CreateNewBlock so the template is already valid; nothing extra needed here.
+
             // This is normally called in IncrementExtraNonce, but because we aren't doing that anymore.
             // We need to make sure we build the merkleroot.
             pblock->hashMerkleRoot = pblock->BuildMerkleTree();

--- a/src/secp256k1/Makefile.am
+++ b/src/secp256k1/Makefile.am
@@ -175,3 +175,7 @@ endif
 if ENABLE_MODULE_RECOVERY
 include src/modules/recovery/Makefile.am.include
 endif
+
+if ENABLE_MODULE_VRF
+include src/modules/vrf/Makefile.am.include
+endif

--- a/src/secp256k1/configure.ac
+++ b/src/secp256k1/configure.ac
@@ -134,6 +134,11 @@ AC_ARG_ENABLE(module_recovery,
     [enable_module_recovery=$enableval],
     [enable_module_recovery=no])
 
+AC_ARG_ENABLE(module_vrf,
+    AS_HELP_STRING([--enable-module-vrf],[enable ECVRF-SECP256K1-SHA256-TAI module (default is no)]),
+    [enable_module_vrf=$enableval],
+    [enable_module_vrf=no])
+
 AC_ARG_ENABLE(jni,
     AS_HELP_STRING([--enable-jni],[enable libsecp256k1_jni (default is auto)]),
     [use_jni=$enableval],
@@ -435,6 +440,10 @@ if test x"$enable_module_recovery" = x"yes"; then
   AC_DEFINE(ENABLE_MODULE_RECOVERY, 1, [Define this symbol to enable the ECDSA pubkey recovery module])
 fi
 
+if test x"$enable_module_vrf" = x"yes"; then
+  AC_DEFINE(ENABLE_MODULE_VRF, 1, [Define this symbol to enable the ECVRF module])
+fi
+
 AC_C_BIGENDIAN()
 
 if test x"$use_external_asm" = x"yes"; then
@@ -450,6 +459,7 @@ AC_MSG_NOTICE([Using endomorphism optimizations: $use_endomorphism])
 AC_MSG_NOTICE([Building for coverage analysis: $enable_coverage])
 AC_MSG_NOTICE([Building ECDH module: $enable_module_ecdh])
 AC_MSG_NOTICE([Building ECDSA pubkey recovery module: $enable_module_recovery])
+AC_MSG_NOTICE([Building ECVRF module: $enable_module_vrf])
 AC_MSG_NOTICE([Using jni: $use_jni])
 
 if test x"$enable_experimental" = x"yes"; then
@@ -481,6 +491,7 @@ AM_CONDITIONAL([USE_BENCHMARK], [test x"$use_benchmark" = x"yes"])
 AM_CONDITIONAL([USE_ECMULT_STATIC_PRECOMPUTATION], [test x"$set_precomp" = x"yes"])
 AM_CONDITIONAL([ENABLE_MODULE_ECDH], [test x"$enable_module_ecdh" = x"yes"])
 AM_CONDITIONAL([ENABLE_MODULE_RECOVERY], [test x"$enable_module_recovery" = x"yes"])
+AM_CONDITIONAL([ENABLE_MODULE_VRF], [test x"$enable_module_vrf" = x"yes"])
 AM_CONDITIONAL([USE_JNI], [test x"$use_jni" == x"yes"])
 AM_CONDITIONAL([USE_EXTERNAL_ASM], [test x"$use_external_asm" = x"yes"])
 AM_CONDITIONAL([USE_ASM_ARM], [test x"$set_asm" = x"arm"])

--- a/src/secp256k1/include/secp256k1_vrf.h
+++ b/src/secp256k1/include/secp256k1_vrf.h
@@ -1,0 +1,19 @@
+#ifndef SECP256K1_VRF_H
+#define SECP256K1_VRF_H
+#include "secp256k1.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+/* ECVRF-SECP256K1-SHA256-TAI (draft-05, suite 0xFE). proof=81B, output=32B. */
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_vrf_prove(
+    unsigned char proof[81], const unsigned char *seckey, secp256k1_pubkey* pubkey,
+    const void *msg, const unsigned int msglen) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_vrf_verify(
+    unsigned char output[32], const unsigned char proof[81], const unsigned char pk[33],
+    const void *msg, const unsigned int msglen) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_vrf_proof_to_hash(
+    unsigned char output[32], const unsigned char proof[81]) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2);
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/secp256k1/src/modules/vrf/Makefile.am.include
+++ b/src/secp256k1/src/modules/vrf/Makefile.am.include
@@ -1,0 +1,3 @@
+include_HEADERS += include/secp256k1_vrf.h
+noinst_HEADERS += src/modules/vrf/main_impl.h
+noinst_HEADERS += src/modules/vrf/tests_impl.h

--- a/src/secp256k1/src/modules/vrf/main_impl.h
+++ b/src/secp256k1/src/modules/vrf/main_impl.h
@@ -1,0 +1,481 @@
+/**********************************************************************
+ * Copyright (c) 2020 Aergo Foundation                                *
+ * Distributed under the MIT software license, see the accompanying   *
+ * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ **********************************************************************/
+
+#define VRF_SUITE 0xFE  /* for compatibility with witnet/vrf-rs */
+
+#define memzero(ptr,size) memset(ptr,0,size);
+
+#define VRF_DEBUG_PRINT(X)
+
+static void sha256(unsigned char *result, const void *data, const unsigned int len) {
+    secp256k1_sha256 sha256;
+    secp256k1_sha256_initialize(&sha256);
+    secp256k1_sha256_write(&sha256, data, len);
+    secp256k1_sha256_finalize(&sha256, result);
+}
+
+/******************************************************************************/
+/** CALCULATIONS **************************************************************/
+/******************************************************************************/
+
+/*
+** result = a*b+c (modulo the group order)
+**
+** Implemented using secp256k1_scalar
+*/
+static int secp256k1_scalar32_muladd(
+  unsigned char *result,
+  const unsigned char *a,
+  const unsigned char *b,
+  const unsigned char *c
+){
+  secp256k1_scalar r_scalar, a_scalar, b_scalar, c_scalar, t_scalar;
+  int overflow = 0, ret = 0;
+
+  /* Parse a */
+  secp256k1_scalar_set_b32(&a_scalar, a, &overflow);
+  if (overflow || secp256k1_scalar_is_zero(&a_scalar)) goto loc_exit;
+  /* Parse b */
+  secp256k1_scalar_set_b32(&b_scalar, b, &overflow);
+  if (overflow || secp256k1_scalar_is_zero(&b_scalar)) goto loc_exit;
+  /* Parse c */
+  secp256k1_scalar_set_b32(&c_scalar, c, &overflow);
+  if (overflow || secp256k1_scalar_is_zero(&c_scalar)) goto loc_exit;
+
+  /* r=a*b+c (mod q) */
+  secp256k1_scalar_mul(&t_scalar, &a_scalar, &b_scalar);
+  secp256k1_scalar_add(&r_scalar, &t_scalar, &c_scalar);
+
+  secp256k1_scalar_get_b32(result, &r_scalar);
+  ret = 1;
+
+loc_exit:
+  secp256k1_scalar_clear(&a_scalar);
+  secp256k1_scalar_clear(&b_scalar);
+  secp256k1_scalar_clear(&c_scalar);
+  secp256k1_scalar_clear(&t_scalar);
+  secp256k1_scalar_clear(&r_scalar);
+  return ret;
+}
+
+#ifdef VRF_UNUSED_FUNCTIONS
+/*
+** result = a*b+c (modulo the group order)
+**
+** Implemented using bignum
+*/
+static int secp256k1_scalar32_muladd(
+  unsigned char *result,
+  const unsigned char a[32],
+  const unsigned char b[32],
+  const unsigned char c[32]
+){
+  secp256k1_num r_num, a_num, b_num, c_num, order;
+  unsigned char zero[1] = "";
+  int ret = 0;
+
+  /* Parse a */
+  secp256k1_num_set_bin(&a_num, a, 32);
+  secp256k1_num_set_bin(&b_num, b, 32);
+  secp256k1_num_set_bin(&c_num, c, 32);
+
+  /* r=a*b+c (mod q) */
+  secp256k1_num_mul(&r_num, &a_num, &b_num);
+  secp256k1_num_add(&r_num, &r_num, &c_num);
+  secp256k1_scalar_order_get_num(&order);
+  secp256k1_num_mod(&r_num, &order);
+
+  memset(result, 0, 32);
+  secp256k1_num_get_bin(result, 32, &r_num);
+  ret = 1;
+
+loc_exit:
+  secp256k1_num_set_bin(&a_num, zero, 1);
+  secp256k1_num_set_bin(&b_num, zero, 1);
+  secp256k1_num_set_bin(&c_num, zero, 1);
+  secp256k1_num_set_bin(&r_num, zero, 1);
+  secp256k1_num_set_bin(&order, zero, 1);
+  return ret;
+}
+#endif
+
+/*
+** Multiply a scalar by a point.
+** Accepts a raw scalar as an unsigned 32 bytes octet.
+** Returns the result as a ge point.
+*/
+static int secp256k1_vrf_ecmult(secp256k1_ge *result, const unsigned char scalar32[32], const secp256k1_ge *point) {
+  secp256k1_gej result_gej;
+  secp256k1_scalar scalar;
+  int overflow = 0, ret = 0;
+
+  secp256k1_scalar_set_b32(&scalar, scalar32, &overflow);
+  if (overflow || secp256k1_scalar_is_zero(&scalar)) goto loc_exit;
+
+  secp256k1_ecmult_const(&result_gej, point, &scalar);
+
+  secp256k1_ge_set_gej(result, &result_gej);
+  secp256k1_gej_clear(&result_gej);
+  ret = 1;
+loc_exit:
+  secp256k1_scalar_clear(&scalar);
+  return ret;
+}
+
+/*
+** Multiply a scalar by the base point.
+** Accepts a raw scalar as an unsigned 32 bytes octet.
+** Returns the result as a ge point.
+*/
+static int secp256k1_vrf_ecmult_base(secp256k1_ge *result, const unsigned char scalar32[32]) {
+  return secp256k1_vrf_ecmult(result, scalar32, &secp256k1_ge_const_g);
+}
+
+#ifdef VRF_UNUSED_FUNCTIONS
+
+/*
+** These 2 functions do not use the constant time ecmul functions.
+** They require a secp256k1_context to be supplied.
+*/
+
+/*
+** Multiply a scalar by a point.
+** Accepts a raw scalar as an unsigned 32 bytes octet.
+** Returns the result as a ge point.
+*/
+static int secp256k1_vrf_ecmult(const secp256k1_ecmult_gen_context* ctx, secp256k1_ge *result, const unsigned char scalar32[32], secp256k1_ge *point) {
+  secp256k1_gej result_gej, point_gej;
+  secp256k1_scalar scalar;
+  int overflow = 0, ret = 0;
+
+  secp256k1_scalar_set_b32(&scalar, scalar32, &overflow);
+  if (overflow || secp256k1_scalar_is_zero(&scalar)) goto loc_exit;
+
+  secp256k1_gej_set_ge(&point_gej, point);
+
+  secp256k1_ecmult(ctx, &result_gej, &point_gej, &scalar, &zero);
+
+  secp256k1_ge_set_gej(result, &result_gej);
+  secp256k1_gej_clear(&result_gej);
+  secp256k1_gej_clear(&point_gej);
+  ret = 1;
+loc_exit:
+  secp256k1_scalar_clear(&scalar);
+  return ret;
+}
+
+/*
+** Multiply a scalar by a point.
+** Accepts a raw scalar as an unsigned 32 bytes octet.
+** Returns the result as a ge point.
+*/
+static int secp256k1_vrf_ecmult_base(const secp256k1_ecmult_gen_context* ctx, secp256k1_ge *result, const unsigned char scalar32[32]) {
+  secp256k1_gej result_gej;
+  secp256k1_scalar scalar;
+  int overflow = 0, ret = 0;
+
+  secp256k1_scalar_set_b32(&scalar, scalar32, &overflow);
+  if (overflow || secp256k1_scalar_is_zero(&scalar)) goto loc_exit;
+
+  secp256k1_ecmult_gen(ctx, &result_gej, &scalar);
+
+  secp256k1_ge_set_gej(result, &result_gej);
+  secp256k1_gej_clear(&result_gej);
+  ret = 1;
+loc_exit:
+  secp256k1_scalar_clear(&scalar);
+  return ret;
+}
+
+#endif
+
+/*
+** Subtract one point from another by adding one to the other negated (flip sign on Y coordinate)
+*/
+static void secp256k1_vrf_ecsub(secp256k1_ge *result, secp256k1_ge *a, secp256k1_ge *b) {
+  secp256k1_gej result_gej, a_gej;
+  secp256k1_ge b_neg;
+  /* get negated point b */
+  secp256k1_ge_neg(&b_neg, b);
+  /* add the points */
+  secp256k1_gej_set_ge(&a_gej, a);
+  secp256k1_gej_add_ge(&result_gej, &a_gej, &b_neg);
+  secp256k1_ge_set_gej(result, &result_gej);
+  /* clear used variables */
+  secp256k1_ge_clear(&b_neg);
+  secp256k1_gej_clear(&a_gej);
+  secp256k1_gej_clear(&result_gej);
+}
+
+/******************************************************************************/
+/** ECVRF FUNCTIONS ***********************************************************/
+/******************************************************************************/
+
+static int point_to_string(unsigned char *output, const secp256k1_ge *P) {
+    size_t len = 33;
+    if (!output || !P) return 0;
+    memset(output, 0, len);
+    return secp256k1_eckey_pubkey_serialize(P, output, &len, 1);
+}
+
+static int string_to_point(secp256k1_ge *P, const unsigned char input[33]) {
+    if (!P || !input) return 0;
+    return secp256k1_eckey_pubkey_parse(P, input, 33);
+}
+
+/*
+** Hash to curve by the try and increment method
+*/
+static int vrf_hash_to_curve_tai(secp256k1_ge *point, const secp256k1_ge *Y_point, const unsigned char *alpha_string, unsigned int alpha_len) {
+    unsigned char ctr = 0;
+    unsigned char pk_string[33];
+    unsigned char *full_string;
+    unsigned int pk_len, full_len;
+    unsigned int offset = 0;
+
+    if (!point || !Y_point || !alpha_string) return 0;
+
+    point_to_string(pk_string, Y_point);
+    pk_len = 33;
+
+    full_len = 1 + 1 + pk_len + alpha_len + 1;
+    full_string = malloc(full_len);
+    if (!full_string) return 0;
+
+    full_string[0] = VRF_SUITE;
+    full_string[1] = 0x01;
+    offset = 2;
+    buffer_append(full_string, &offset, pk_string, pk_len);
+    buffer_append(full_string, &offset, alpha_string, alpha_len);
+
+    for (;; ctr++) {
+        /* the first byte used by the inplace arbitrary_string_to_point() */
+        unsigned char hash_string[33];
+        /* update the ctr directly on the string */
+        full_string[offset] = ctr;
+        /* calculate the hash_string */
+        sha256(&hash_string[1], full_string, full_len);
+        /* arbitrary_string_to_point (inplace) */
+        hash_string[0] = 0x02;
+        if (string_to_point(point, hash_string) && !secp256k1_ge_is_infinity(point)) {
+          VRF_DEBUG_PRINT(("try_and_increment succeded on ctr = %d\n", ctr));
+          free(full_string);
+          return 1;
+        }
+    }
+}
+
+static void vrf_hash_points(
+    unsigned char ret[16],
+    const secp256k1_ge *P1,
+    const secp256k1_ge *P2,
+    const secp256k1_ge *P3,
+    const secp256k1_ge *P4
+){
+    unsigned char str[2+33*4], hash32[32];
+    str[0] = VRF_SUITE;
+    str[1] = 0x02;
+    point_to_string(str+2+33*0, P1);
+    point_to_string(str+2+33*1, P2);
+    point_to_string(str+2+33*2, P3);
+    point_to_string(str+2+33*3, P4);
+    sha256(hash32, str, sizeof str);
+    memcpy(ret, hash32, 16);
+    memset(hash32, 0, 32);
+}
+
+static void vrf_nonce_generation(unsigned char nonce32[32], const unsigned char seckey[32], const unsigned char *msg, const unsigned int msglen) {
+  unsigned char msg32[32];
+  int count = 0, overflow = 0;
+  sha256(msg32, msg, msglen);
+  while (1) {
+      secp256k1_scalar non;
+      int ret = nonce_function_rfc6979(nonce32, msg32, seckey, NULL, NULL, count);
+      if (!ret) {
+          secp256k1_scalar_clear(&non);
+          break;
+      }
+      secp256k1_scalar_set_b32(&non, nonce32, &overflow);
+      if (!overflow && !secp256k1_scalar_is_zero(&non)) {
+          secp256k1_scalar_clear(&non);
+          break;
+      }
+      count++;
+  }
+}
+
+static int vrf_decode_proof(
+    secp256k1_ge *Gamma,
+    unsigned char c[16],
+    unsigned char s[32],
+    const unsigned char pi[81]
+){
+    /* gamma = decode_point(pi[0:32]) */
+    if (string_to_point(Gamma, pi) == 0) {
+        return 0;
+    }
+    memcpy(c, pi+33, 16); /* c = pi[33:48] */
+    memcpy(s, pi+49, 32); /* s = pi[49:80] */
+    return 1;
+}
+
+int secp256k1_vrf_proof_to_hash(
+    unsigned char beta[32],
+    const unsigned char pi[81]
+){
+    unsigned char c_scalar[16], s_scalar[32];
+    unsigned char hash_input[2+33];
+    secp256k1_ge Gamma_point;
+    /* (Gamma, c, s) = ECVRF_decode_proof(pi_string) */
+    if (!vrf_decode_proof(&Gamma_point, c_scalar, s_scalar, pi)) {
+        return 0;
+    }
+    /* beta_string = Hash(suite_string || three_string || point_to_string(Gamma)) */
+    hash_input[0] = VRF_SUITE;
+    hash_input[1] = 0x03;
+    /* no need to multiply by a cofactor because it is 1 for secp256k1 curve */
+    point_to_string(hash_input+2, &Gamma_point);
+    sha256(beta, hash_input, sizeof hash_input);
+    return 1;
+}
+
+/******************************************************************************/
+/** PROVE *********************************************************************/
+/******************************************************************************/
+
+static int vrf_prove(
+    unsigned char pi[81],
+    const secp256k1_ge *Y_point,
+    const unsigned char x_scalar[32],
+    const unsigned char *alpha, unsigned int alphalen
+){
+    unsigned char h_string[33], k_scalar[32], c_scalar[32];
+    secp256k1_ge  H_point, Gamma_point, kB_point, kH_point;
+    int ret = 0;
+
+    /* hash to the curve using the try and increment approach */
+    if (!vrf_hash_to_curve_tai(&H_point, Y_point, alpha, alphalen)) goto loc_cleanup;
+    point_to_string(h_string, &H_point);
+
+    /* generate the nonce value k in a deterministic pseudorandom fashion */
+    vrf_nonce_generation(k_scalar, x_scalar, h_string, 33);
+
+    /* Gamma = x*H */
+    if (!secp256k1_vrf_ecmult(&Gamma_point, x_scalar, &H_point)) goto loc_cleanup;
+    /* compute k*B */
+    if (!secp256k1_vrf_ecmult_base(&kB_point, k_scalar)) goto loc_cleanup;
+    /* compute k*H */
+    if (!secp256k1_vrf_ecmult(&kH_point, k_scalar, &H_point)) goto loc_cleanup;
+
+    /* c = ECVRF_hash_points(h, gamma, k*B, k*H) */
+    vrf_hash_points(c_scalar+16, &H_point, &Gamma_point, &kB_point, &kH_point);
+    /* zero the first 16 bytes of c_scalar */
+    memset(c_scalar, 0, 16);
+
+    /* output pi */
+    /* pi[0:32] = point_to_string(Gamma) */
+    point_to_string(pi, &Gamma_point);
+    /* pi[33:48] = c (16 bytes) */
+    memmove(pi+33, c_scalar+16, 16);
+    /* pi[49:80] = s = c*x + k (mod q) */
+    secp256k1_scalar32_muladd(pi+49, c_scalar, x_scalar, k_scalar);
+
+    /* everything is OK */
+    ret = 1;
+
+loc_cleanup:
+
+    /* k must remain secret */
+    memzero(k_scalar, sizeof k_scalar);
+
+    /* erase other non-sensitive intermediate state for good measure */
+    memzero(h_string, sizeof h_string);
+    memzero(c_scalar, sizeof c_scalar);
+    memzero(&H_point, sizeof H_point);
+    memzero(&Gamma_point, sizeof Gamma_point);
+    memzero(&kB_point, sizeof kB_point);
+    memzero(&kH_point, sizeof kH_point);
+
+    return ret;
+}
+
+int secp256k1_vrf_prove(
+    unsigned char proof[81],
+    const unsigned char *seckey,
+    secp256k1_pubkey* pubkey,
+    const void *msg,
+    const unsigned int msglen
+){
+    secp256k1_ge Q;
+    int ret;
+    if (!secp256k1_pubkey_load(NULL, &Q, pubkey)) {
+        secp256k1_ge_clear(&Q);
+        return 0;
+    }
+    ret = vrf_prove(proof, &Q, seckey, msg, msglen);
+    secp256k1_ge_clear(&Q);
+    return ret;
+}
+
+/******************************************************************************/
+/** VERIFICATION **************************************************************/
+/******************************************************************************/
+
+static int vrf_validate_key(secp256k1_ge *Y_point, const unsigned char pk_string[33]) {
+    if (string_to_point(Y_point, pk_string) == 0 || secp256k1_ge_is_infinity(Y_point)) {
+        return 0;
+    }
+    return 1;
+}
+
+static int vrf_verify(
+    const secp256k1_ge *Y_point,
+    const unsigned char pi[81],
+    const unsigned char *alpha, const unsigned int alphalen
+){
+    unsigned char c_scalar[32], s_scalar[32], cprime[16];
+    secp256k1_ge H_point, Gamma_point, U_point, V_point;
+    secp256k1_ge sB_point, cY_point, sH_point, cGamma_point;
+
+    if (!vrf_decode_proof(&Gamma_point, c_scalar+16, s_scalar, pi)) {
+        return 0;
+    }
+
+    /* zero the first 16 bytes of c_scalar */
+    memset(c_scalar, 0, 16);
+
+    /* hash to the curve using the try and increment approach */
+    if (!vrf_hash_to_curve_tai(&H_point, Y_point, alpha, alphalen)) return 0;
+
+    /* calculate U = s*B - c*Y */
+    secp256k1_vrf_ecmult_base(&sB_point, s_scalar);      /* compute s*B */
+    secp256k1_vrf_ecmult(&cY_point, c_scalar, Y_point);  /* compute c*Y */
+    secp256k1_vrf_ecsub(&U_point, &sB_point, &cY_point); /* U = s*B - c*Y */
+
+    /* calculate V = s*H -  c*Gamma */
+    secp256k1_vrf_ecmult(&sH_point, s_scalar, &H_point);         /* compute s*H */
+    secp256k1_vrf_ecmult(&cGamma_point, c_scalar, &Gamma_point); /* compute c*Gamma */
+    secp256k1_vrf_ecsub(&V_point, &sH_point, &cGamma_point);     /* V = s*H - c*Gamma */
+
+    /* c = ECVRF_hash_points(h, gamma, U, V) */
+    vrf_hash_points(cprime, &H_point, &Gamma_point, &U_point, &V_point);
+
+    return memcmp(c_scalar+16, cprime, 16) == 0;
+}
+
+int secp256k1_vrf_verify(
+    unsigned char output[32],
+    const unsigned char proof[81],
+    const unsigned char pk[33],
+    const void *msg, const unsigned int msglen
+){
+    secp256k1_ge Y;
+    if ( vrf_validate_key(&Y, pk) && vrf_verify(&Y, proof, msg, msglen)) {
+        return secp256k1_vrf_proof_to_hash(output, proof);
+    } else {
+        return 0;
+    }
+}

--- a/src/secp256k1/src/modules/vrf/tests_impl.h
+++ b/src/secp256k1/src/modules/vrf/tests_impl.h
@@ -1,0 +1,160 @@
+/**********************************************************************
+ * Copyright (c) 2020 Aergo Foundation                                *
+ * Distributed under the MIT software license, see the accompanying   *
+ * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ **********************************************************************/
+
+unsigned char HexToInt(int h){
+  CHECK( (h>='0' && h<='9') ||  (h>='a' && h<='f') ||  (h>='A' && h<='F') );
+  h += 9*(1&(h>>6));
+  return (unsigned char)(h & 0xf);
+}
+
+void from_hex(char *source, int size, unsigned char *dest){
+  char *end = source + size;
+  while( source<end ){
+    unsigned char c1 = *(source++);
+    unsigned char c2 = *(source++);
+    *(dest++) = (HexToInt(c1)<<4) | HexToInt(c2);
+  }
+}
+
+void print_hex(char *desc, unsigned char *data, int size){
+  int i;
+  printf("%s=", desc);
+  for(i=0; i<size; i++){
+    printf("%02X", data[i]);
+  }
+  puts("");
+}
+
+void run_vrf_tests(void) {
+    secp256k1_context *sender;
+    secp256k1_context *receiver;
+    unsigned char proof[81] = {0};
+    unsigned char seckey[32];
+    secp256k1_pubkey pubkey;
+    unsigned char pk[33];
+    size_t pklen = 33;
+    char *msg;
+    unsigned int msglen;
+    unsigned char output[32];
+    int i;
+
+    sender   = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    receiver = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+
+    msg = "sample";
+    msglen = strlen(msg);
+
+
+    {  /* test nonce generation */
+
+    unsigned char gen_nonce[32], exp_nonce[32];
+
+    from_hex("c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721", 64, seckey);
+
+    vrf_nonce_generation(gen_nonce, seckey, (unsigned char *)msg, msglen);
+
+    from_hex("A6E3C57DD01ABE90086538398355DD4C3B17AA873382B0F24D6129493D8AAD60", 64, exp_nonce);
+
+    print_hex("exp=", exp_nonce, 32);
+    print_hex("gen=", gen_nonce, 32);
+
+    CHECK(memcmp(exp_nonce, gen_nonce, 32) == 0);
+
+    }
+
+
+    {  /* test prove */
+  
+    unsigned char expected_proof[81] = {0};
+    
+    from_hex("c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721", 64, seckey);
+
+    CHECK(secp256k1_ec_pubkey_create(sender, &pubkey, seckey) == 1);
+    CHECK(secp256k1_ec_pubkey_serialize(sender, pk, &pklen, &pubkey, SECP256K1_EC_COMPRESSED) == 1);
+
+    CHECK(secp256k1_vrf_prove(proof, seckey, &pubkey, msg, msglen) == 1);
+
+    from_hex("031f4dbca087a1972d04a07a779b7df1caa99e0f5db2aa21f3aecc4f9e10e85d08748c9fbe6b95d17359707bfb8e8ab0c93ba0c515333adcb8b64f372c535e115ccf66ebf5abe6fadb01b5efb37c0a0ec9", 162, expected_proof);
+
+    print_hex("expec=", expected_proof, 81);
+    print_hex("proof=", proof, 81);
+
+    CHECK(memcmp(proof, expected_proof, 81) == 0);
+
+    }
+
+
+    /* test verify on invalid and valid proofs */
+
+    for(i=0; i<81; i++){
+      unsigned char temp = proof[i];
+      if (proof[i] == 0x00) proof[i] = 0x01; else proof[i] = 0x00;
+      CHECK(secp256k1_vrf_verify(output, proof, pk, msg, msglen) == 0);
+      proof[i] = temp;
+      CHECK(secp256k1_vrf_verify(output, proof, pk, msg, msglen) == 1);
+    }
+
+    print_hex("output=", output, 32);
+
+
+    /* test the same message with different provers */
+
+    for(i=0; i<10; i++){
+
+      secp256k1_rand256(seckey);
+
+      CHECK(secp256k1_ec_pubkey_create(sender, &pubkey, seckey) == 1);
+      CHECK(secp256k1_ec_pubkey_serialize(sender, pk, &pklen, &pubkey, SECP256K1_EC_COMPRESSED) == 1);
+
+      CHECK(secp256k1_vrf_prove(proof, seckey, &pubkey, msg, msglen) == 1);
+      print_hex("proof=", proof, 81);
+
+      CHECK(secp256k1_vrf_verify(output, proof, pk, msg, msglen) == 1);
+      print_hex("output=", output, 32);
+
+    }
+
+
+    /* test different messages with the same prover */
+
+    for(i=0; i<10; i++){
+      char buf[128];
+
+      sprintf(buf, "message%d", i);
+      msg = buf;
+      msglen = strlen(msg);
+
+      CHECK(secp256k1_vrf_prove(proof, seckey, &pubkey, msg, msglen) == 1);
+      print_hex("proof=", proof, 81);
+
+      CHECK(secp256k1_vrf_verify(output, proof, pk, msg, msglen) == 1);
+      print_hex("output=", output, 32);
+
+    }
+
+
+    {  /* test verify */
+
+    unsigned char expected_output[32] = {0};
+
+    msg = "sample";
+    msglen = strlen(msg);
+
+    from_hex("032c8c31fc9f990c6b55e3865a184a4ce50e09481f2eaeb3e60ec1cea13a6ae645", 66, pk);
+    from_hex("031f4dbca087a1972d04a07a779b7df1caa99e0f5db2aa21f3aecc4f9e10e85d0814faa89697b482daa377fb6b4a8b0191a65d34a6d90a8a2461e5db9205d4cf0bb4b2c31b5ef6997a585a9f1a72517b6f", 162, proof);
+
+    CHECK(secp256k1_vrf_verify(output, proof, pk, msg, msglen) == 1);
+
+    from_hex("612065e309e937ef46c2ef04d5886b9c6efd2991ac484ec64a9b014366fc5d81", 64, expected_output);
+
+    print_hex("expect=", expected_output, 32);
+    print_hex("output=", output, 32);
+
+    CHECK(memcmp(output, expected_output, 32) == 0);
+
+    }
+
+}

--- a/src/secp256k1/src/secp256k1.c
+++ b/src/secp256k1/src/secp256k1.c
@@ -5,6 +5,9 @@
  **********************************************************************/
 
 #include "include/secp256k1.h"
+#ifdef ENABLE_MODULE_VRF
+# include "include/secp256k1_vrf.h"
+#endif
 
 #include "util.h"
 #include "num_impl.h"
@@ -581,4 +584,13 @@ int secp256k1_ec_pubkey_combine(const secp256k1_context* ctx, secp256k1_pubkey *
 
 #ifdef ENABLE_MODULE_RECOVERY
 # include "modules/recovery/main_impl.h"
+#endif
+
+#ifdef ENABLE_MODULE_VRF
+/* helper used by the VRF module (mirrors aergo/secp256k1-vrf); bundled lib lacks it */
+static SECP256K1_INLINE void buffer_append(unsigned char *buf, unsigned int *offset, const void *data, unsigned int len) {
+    memcpy(buf + *offset, data, len);
+    *offset += len;
+}
+# include "modules/vrf/main_impl.h"
 #endif

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -555,7 +555,11 @@ bool CBlockTreeDB::LoadBlockIndexGuts(std::function<CBlockIndex*(const uint256&)
                 }
 
                 if (header.IsPON()) {
-                    if (!CheckProofOfNode(GetPONHash(header), pindexNew->nBits, Params().GetConsensus(), pindexNew->nHeight) && !IsEmergencyBlock(header))
+                    // For PON-VRF blocks the eligibility value is the committed VRF output, not GetPONHash.
+                    uint256 ponEligibilityValue = (header.nVersion >= CBlockHeader::PON_VRF_VERSION)
+                                                      ? header.nodesVrfOutput
+                                                      : GetPONHash(header);
+                    if (!CheckProofOfNode(ponEligibilityValue, pindexNew->nBits, Params().GetConsensus(), pindexNew->nHeight) && !IsEmergencyBlock(header))
                         return error("LoadBlockIndex(): CheckProofOfWork failed: %s", pindexNew->ToString());
                 } else if (!isCheckpointed) {
                     // Only verify PoW for non-checkpointed POW blocks

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -532,6 +532,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(std::function<CBlockIndex*(const uint256&)
                 pindexNew->nSolution      = diskindex.nSolution;
                 pindexNew->nodesCollateral = diskindex.nodesCollateral;
                 pindexNew->vchBlockSig    = diskindex.vchBlockSig;
+                pindexNew->nodesVrfOutput = diskindex.nodesVrfOutput;
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nCachedBranchId = diskindex.nCachedBranchId;
                 pindexNew->nTx            = diskindex.nTx;

--- a/src/version.h
+++ b/src/version.h
@@ -10,7 +10,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 170021;
+static const int PROTOCOL_VERSION = 170022;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
# PON-VRF: VRF leader election (closes the leader-election grinding vulnerability)

## Summary
Replaces Proof-of-Node's grindable leader election with a **verifiable random function (VRF)** election that reuses the existing fluxnode operator key. Leadership is now an un-grindable, verifiable draw, and ties converge deterministically. Gated behind a new `UPGRADE_PON_VRF` network upgrade, so it ships **inert** until an activation height is scheduled.

## Problem
PON leader eligibility was `H(collateral, prevBlockHash, slot) ≤ target`. Because that hash depends on block content the proposer controls, a proposer can **grind** its inputs to bias who is eligible to lead — there is no cooldown and no consensus rank check. This lets a sufficiently resourced node disproportionately influence leader selection.

## Solution
- **VRF eligibility:** `y = VRF(operator_key, H(epoch_seed ‖ slot))`; eligible iff `y ≤ target`.
  - `epoch_seed` is derived from a **buried block window** (beyond the reorg horizon) that the current proposer could not have authored → not grindable.
  - The **slot** is mixed in so eligibility is a fresh draw each slot (leader rotation / liveness).
- **Reuses the existing secp256k1 operator key** — no new key material for operators.
- The VRF **output is committed to the block hash** (so it is signed and immutable); the proof is carried but excluded from the hash (self-validating against the output).
- **Deterministic fork choice:** at equal work/height, the **lowest VRF output wins**, so the network converges.

## What's in this PR (by area)
- **Crypto:** ECVRF (`ECVRF-SECP256K1-SHA256-TAI`) via a vendored `secp256k1-vrf` module + `src/crypto/ecvrf.{h,cpp}`.
- **Block format:** `PON_VRF_VERSION = 101`; `nodesVrfOutput` (committed) + `nodesVrfProof` (excluded from hash).
- **Consensus:** `UPGRADE_PON_VRF` network upgrade (branch id `0x76b809bb`); per-slot VRF eligibility; contextual VRF-proof verification; lowest-VRF fork-choice tie-break.
- **Production / validation / relay** — every site that builds, hashes, validates, relays, or reads a block header now handles the committed VRF output: `CreateNewBlock`, `CheckBlockHeader`, `ReadBlockFromDisk`, `LoadBlockIndex`, and the `cmpheaders` compact-header serialization.
- **Networking:** `PROTOCOL_VERSION` and `UPGRADE_PON_VRF.nProtocolVersion` bumped to **170022** so VRF-capable peers are distinguishable and peers below 170022 are rejected once the upgrade activates.

## Testing
- **25 gtests pass** — ECVRF prove/verify round-trip, output-committed/proof-excluded serialization, and fork-choice convergence.
- **Live local testnet validation** — confirmed fluxnodes minting `v101` VRF blocks accepted under the **real (unbypassed) verifier**; multi-node header sync and concurrent minting validated up to ~100 nodes; orphan-rate measurements confirm the difficulty target (eligible-nodes-per-slot) is the dominant orphan lever.

## Activation & deployment notes
- **Ships inert:** `PON_VRF` is `NO_ACTIVATION_HEIGHT` on mainnet and regtest. Testnet is set to a **PLACEHOLDER (`9999999`)** — **replace with a scheduled testnet height (above the current tip) before tagging.**
- Protocol-version gating ensures a clean upgrade window: nothing changes until activation, after which sub-170022 peers are dropped.

## Follow-ups (not blocking testnet)
- Validate on the live testnet that the difficulty retarget keeps eligible-nodes-per-slot small at scale (the orphan driver).
- Optional networking optimization: priority-aware "announce-first" relay to further cut orphans at large N.
- **Constant-time / side-channel audit of the VRF module before mainnet.**

## Commits (in order)

_Crypto foundation_
- `ca735752a` — Add ECVRF-secp256k1 module (vendored from aergo) + ecvrf C++ boundary

_Consensus core_
- `474a792ff` — PON: VRF leader election (consensus) — closes leader-election grinding
- `d418724fe` — PON-VRF: deterministic fork choice via lowest-VRF tie-break

_Tests_
- `5c393c205` — PON-VRF: extract `ComparePonForkChoice` + gtests for fork-choice convergence
- `51a941b8c` — PON-VRF: gtests for block serialization + real ECVRF prove/verify path

_Completeness fixes (found via live testnet block production)_
- `382c2e0e3` — populate VRF fields in `CreateNewBlock` so VRF blocks can be produced
- `8bcd4f1f9` — per-slot eligibility, `CheckBlockHeader` + compact-header VRF support
- `52f49d786` — `ReadBlockFromDisk` must check the VRF output, not `GetPONHash`
- `494486f27` — `LoadBlockIndex` must check the VRF output, not `GetPONHash`

_Deployment_
- `3792a6e81` — PLACEHOLDER testnet activation height — **SET BEFORE TAGGING**
- `73fda1b54` — bump protocol version to 170022 for VRF wire format
