### PR TITLE
Treat NO_ACTIVATION_HEIGHT as never active in IsPONActive

### DIFF
--- a/src/pon/pon-fork.cpp
+++ b/src/pon/pon-fork.cpp
@@ -13,9 +13,13 @@
 bool IsPONActive(int nHeight)
 {
     int ponActivationHeight = GetPONActivationHeight();
-    
-    // PON is active if we're at or past the activation height
-    // and activation height is set (not NO_ACTIVATION_HEIGHT)
+
+    // NO_ACTIVATION_HEIGHT means PON never activates on this network.
+    if (ponActivationHeight == Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT) {
+        return false;
+    }
+
+    // PON is active once we are at or past the activation height.
     return nHeight >= ponActivationHeight;
 }
 


### PR DESCRIPTION
`IsPONActive` returns true at every height when the PON activation height is `NO_ACTIVATION_HEIGHT` (-1), because `nHeight >= -1` always holds — the function's own comment already states the opposite intent. This adds the missing guard: an unset activation height means PON is not active.

Effect by network:

- **Mainnet, testnet: none.** Both set explicit PON activation heights.
- **Regtest:** PON is no longer unconditionally active from genesis. Regtest becomes PoW by default with PON opt-in via `-ponactivation`, making PON consistent with how every other upgrade gate behaves (`NetworkUpgradeActive` treats `NO_ACTIVATION_HEIGHT` as disabled).

This is kept as a single-commit PR so the consensus-adjacent change can be reviewed in isolation.

Coordination note: #284 modifies the same function. Landing this first is recommended, with #284 rebasing over it; #284's new `IsPONVRFActive` follows the same unguarded comparison and should adopt the same guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
