### PR TITLE
Regtest upgrade-activation controls and daemon fixes

### DIFF
--- a/src/amqp/amqpsender.h
+++ b/src/amqp/amqpsender.h
@@ -59,8 +59,15 @@ class AMQPSender : public proton::messaging_handler {
             throw std::runtime_error("amqp connection was terminated");
         }
 
+        // The connection is established asynchronously by the container thread
+        // and may be briefly inactive during startup or a transient reconnect.
+        // The message has already been queued, so leave it to be flushed from
+        // on_sendable once the connection is active rather than reporting a
+        // failure: the notification interface tears a notifier down permanently
+        // on a single failed send, which would silently stop all further
+        // notifications of that type for the life of the process.
         if (!conn_.active()) {
-            throw std::runtime_error("amqp connection is not active");
+            return;
         }
 
         while (messages_.size() > 0) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1200,14 +1200,38 @@ bool AppInit2(std::vector<std::thread>& threadGroup, CScheduler& scheduler)
                 return InitError(strprintf("Invalid nActivationHeight (%s)", vDeploymentParams[1]));
             }
             bool found = false;
+            // An upgrade can be selected by name (e.g. "PON"), by its UpgradeIndex
+            // enum value (e.g. "10"), or by branch id hex. Name and index target one
+            // upgrade unambiguously; the branch-id form is ambiguous because every
+            // post-Sprout Flux upgrade shares a branch id, so it resolves to the
+            // first match as before. Only treat the selector as an index when it
+            // parses fully as an integer, so a branch id like "5ba81b19" does not
+            // silently match a leading-digit index.
+            const std::string selector = ToLower(vDeploymentParams[0]);
+            int nSelectorIndex = -1;
+            if (!ParseInt32(vDeploymentParams[0], &nSelectorIndex)) {
+                nSelectorIndex = -1;
+            }
             // Exclude Base from upgrades
             for (auto i = Consensus::BASE_SPROUT + 1; i < Consensus::MAX_NETWORK_UPGRADES; ++i)
             {
-                if (vDeploymentParams[0].compare(HexInt(NetworkUpgradeInfo[i].nBranchId)) == 0) {
+                if (selector == ToLower(NetworkUpgradeInfo[i].strName) || nSelectorIndex == i) {
                     UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex(i), nActivationHeight);
                     found = true;
-                    LogPrintf("Setting network upgrade activation parameters for %s to height=%d\n", vDeploymentParams[0], nActivationHeight);
+                    LogPrintf("Setting network upgrade activation parameters for %s to height=%d\n", NetworkUpgradeInfo[i].strName, nActivationHeight);
                     break;
+                }
+            }
+            if (!found) {
+                // Branch-id form (ambiguous; first matching upgrade wins, as before).
+                for (auto i = Consensus::BASE_SPROUT + 1; i < Consensus::MAX_NETWORK_UPGRADES; ++i)
+                {
+                    if (vDeploymentParams[0].compare(HexInt(NetworkUpgradeInfo[i].nBranchId)) == 0) {
+                        UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex(i), nActivationHeight);
+                        found = true;
+                        LogPrintf("Setting network upgrade activation parameters for %s to height=%d\n", vDeploymentParams[0], nActivationHeight);
+                        break;
+                    }
                 }
             }
             if (!found) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -505,6 +505,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-stopafterblockimport", strprintf("Stop running after importing blocks from disk (default: %u)", 0));
         strUsage += HelpMessageOpt("-nuparams=hexBranchId:activationHeight", "Use given activation height for specified network upgrade (regtest-only)");
         strUsage += HelpMessageOpt("-ponactivation=height", "Set the PON activation height (regtest-only); use a high value to mine PoW blocks that pay the wallet");
+        strUsage += HelpMessageOpt("-acadiaactivation=height", "Set the ACADIA upgrade activation height (regtest-only); activates Overwintered transactions so signing carries a consensus branch id");
     }
     string debugCategories = "addrman, alert, bench, coindb, db, estimatefee, http, libevent, lock, mempool, net, partitioncheck, pow, proxy, prune, "
                              "rand, reindex, rpc, selectcoins, tor, zmq, zrpc, zrpcunsafe (implies zrpc)"; // Don't translate these
@@ -1229,6 +1230,22 @@ bool AppInit2(std::vector<std::thread>& threadGroup, CScheduler& scheduler)
         }
         UpdateNetworkUpgradeParameters(Consensus::UPGRADE_PON, nPonActivationHeight);
         LogPrintf("Setting PON activation height to %d\n", nPonActivationHeight);
+    }
+
+    // ACADIA shares its branch id with several other upgrades, so -nuparams
+    // cannot target it (the matcher stops at the first id match). This regtest
+    // flag activates ACADIA directly so createrawtransaction produces
+    // Overwintered transactions that carry a consensus branch id for signing.
+    if (mapArgs.count("-acadiaactivation")) {
+        if (Params().NetworkIDString() != "regtest") {
+            return InitError("-acadiaactivation may only be set on regtest.");
+        }
+        int nAcadiaActivationHeight;
+        if (!ParseInt32(mapArgs["-acadiaactivation"], &nAcadiaActivationHeight)) {
+            return InitError(strprintf("Invalid -acadiaactivation height (%s)", mapArgs["-acadiaactivation"]));
+        }
+        UpdateNetworkUpgradeParameters(Consensus::UPGRADE_ACADIA, nAcadiaActivationHeight);
+        LogPrintf("Setting ACADIA activation height to %d\n", nAcadiaActivationHeight);
     }
 
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -416,7 +416,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-banscore=<n>", strprintf(_("Threshold for disconnecting misbehaving peers (default: %u)"), 100));
     strUsage += HelpMessageOpt("-bantime=<n>", strprintf(_("Number of seconds to keep misbehaving peers from reconnecting (default: %u)"), 86400));
     strUsage += HelpMessageOpt("-bind=<addr>", _("Bind to given address and always listen on it. Use [host]:port notation for IPv6"));
-    strUsage += HelpMessageOpt("-connect=<ip>", _("Connect only to the specified node(s)"));
+    strUsage += HelpMessageOpt("-connect=<ip>", _("Connect only to the specified node(s); -connect=0 disables automatic outbound connections"));
     strUsage += HelpMessageOpt("-discover", _("Discover own IP addresses (default: 1 when listening and no -externalip or -proxy)"));
     strUsage += HelpMessageOpt("-dns", _("Allow DNS lookups for -addnode, -seednode and -connect") + " " + _("(default: 1)"));
     strUsage += HelpMessageOpt("-dnsseed", _("Query for peer addresses via DNS lookup, if low on addresses (default: 1 unless -connect)"));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -504,6 +504,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-flushwallet", strprintf("Run a thread to flush wallet periodically (default: %u)", 1));
         strUsage += HelpMessageOpt("-stopafterblockimport", strprintf("Stop running after importing blocks from disk (default: %u)", 0));
         strUsage += HelpMessageOpt("-nuparams=hexBranchId:activationHeight", "Use given activation height for specified network upgrade (regtest-only)");
+        strUsage += HelpMessageOpt("-ponactivation=height", "Set the PON activation height (regtest-only); use a high value to mine PoW blocks that pay the wallet");
     }
     string debugCategories = "addrman, alert, bench, coindb, db, estimatefee, http, libevent, lock, mempool, net, partitioncheck, pow, proxy, prune, "
                              "rand, reindex, rpc, selectcoins, tor, zmq, zrpc, zrpcunsafe (implies zrpc)"; // Don't translate these
@@ -1212,6 +1213,22 @@ bool AppInit2(std::vector<std::thread>& threadGroup, CScheduler& scheduler)
                 return InitError(strprintf("Invalid network upgrade (%s)", vDeploymentParams[0]));
             }
         }
+    }
+
+    // Allow setting the PON activation height directly on regtest. PON shares a
+    // branch id with several earlier upgrades, so -nuparams cannot target it;
+    // this is the only way to push PON past a test (e.g. to mine PoW blocks
+    // that pay the wallet) or to activate it at a chosen height.
+    if (mapArgs.count("-ponactivation")) {
+        if (Params().NetworkIDString() != "regtest") {
+            return InitError("-ponactivation may only be set on regtest.");
+        }
+        int nPonActivationHeight;
+        if (!ParseInt32(mapArgs["-ponactivation"], &nPonActivationHeight)) {
+            return InitError(strprintf("Invalid -ponactivation height (%s)", mapArgs["-ponactivation"]));
+        }
+        UpdateNetworkUpgradeParameters(Consensus::UPGRADE_PON, nPonActivationHeight);
+        LogPrintf("Setting PON activation height to %d\n", nPonActivationHeight);
     }
 
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -686,7 +686,7 @@ void static BitcoinMiner(const CChainParams& chainparams)
 
     try {
         //throw an error if no script was provided
-        if (!coinbaseScript->reserveScript.size())
+        if (!coinbaseScript || !coinbaseScript->reserveScript.size())
             throw std::runtime_error("No coinbase script available (mining requires a wallet or -mineraddress)");
 
         while (!ShutdownRequested()) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1446,6 +1446,13 @@ void static ProcessOneShot()
 
 void ThreadOpenConnections()
 {
+    // -connect=0 means no automatic outbound connections at all: without this
+    // the "0" would be dialed as a hostname forever (and handed to the SOCKS
+    // proxy when one is configured).
+    if (mapArgs.count("-connect") && mapMultiArgs["-connect"].size() == 1 &&
+        mapMultiArgs["-connect"][0] == "0")
+        return;
+
     // Connect to specific addresses
     if (mapArgs.count("-connect") && mapMultiArgs["-connect"].size() > 0)
     {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -204,7 +204,6 @@ UniValue blockToDeltasJSON(const CBlock& block, const CBlockIndex* blockindex)
             if (IsValidDestination(dest)) {
                 delta.pushKV("address", EncodeDestination(dest));
             }
-            delta.pushKV("address", EncodeDestination(dest));
             delta.pushKV("satoshis", out.nValue);
             delta.pushKV("index", (int)k);
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -192,7 +192,7 @@ UniValue generate(const UniValue& params, bool fHelp)
     GetMainSignals().ScriptForMining(coinbaseScript);
 
     //throw an error if no script was provided
-    if (!coinbaseScript->reserveScript.size())
+    if (!coinbaseScript || !coinbaseScript->reserveScript.size())
         throw JSONRPCError(RPC_INTERNAL_ERROR, "No coinbase script available (mining requires a wallet or -mineraddress)");
 
     {   // Don't keep cs_main locked
@@ -673,7 +673,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
         GetMainSignals().ScriptForMining(coinbaseScript);
 
         // Throw an error if no script was provided
-        if (!coinbaseScript->reserveScript.size())
+        if (!coinbaseScript || !coinbaseScript->reserveScript.size())
             throw JSONRPCError(RPC_INTERNAL_ERROR, "No coinbase script available (mining requires a wallet or -mineraddress)");
 
         pblocktemplate = CreateNewBlock(Params(), coinbaseScript->reserveScript, &mapFluxnodePayouts);

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -11,6 +11,7 @@
 #include "primitives/block.h"
 #include "chain.h"
 #include "consensus/validation.h"
+#include "miner.h"
 
 #include <list>
 #include <unordered_map>
@@ -249,6 +250,14 @@ void CMainSignals::ScriptForMining(std::shared_ptr<CReserveScript>& script)
     m_internals->Iterate([&](CValidationInterface& callbacks) {
         callbacks.GetScriptForMining(script);
     });
+#ifdef ENABLE_MINING
+    // The wallet's GetScriptForMining returns nothing when -mineraddress is set,
+    // and with -disablewallet no interface is registered at all. In both cases the
+    // -mineraddress script must come from here so that mining honours -mineraddress.
+    if (!script || !script->reserveScript.size()) {
+        GetScriptForMinerAddress(script);
+    }
+#endif // ENABLE_MINING
 }
 
 void CMainSignals::BlockFound(const uint256 &hash)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3814,6 +3814,32 @@ DBErrors CWallet::LoadWallet(bool& fFirstRunRet)
         return nLoadWalletRet;
     fFirstRunRet = !vchDefaultKey.IsValid();
 
+    // A rescan (e.g. after z_importkey) persists each note's witness deque via
+    // CWalletTx::WriteToDisk, but nWitnessCacheSize is persisted only by
+    // SetBestChain, which a rescan does not call. A node restarted between the
+    // two reloads a stale, smaller nWitnessCacheSize alongside the larger note
+    // witness deques, which trips the nWitnessCacheSize >= witnesses.size()
+    // assertion in IncrementNoteWitnesses on the next connected block. The
+    // witnesses themselves are correct, so restore the invariant by raising the
+    // counter to the largest reloaded witness deque; the spendable (front)
+    // witness is left untouched, and a healthy wallet (where the two are
+    // persisted together by SetBestChain) is unaffected.
+    {
+        LOCK(cs_wallet);
+        size_t nMaxWitnesses = 0;
+        for (const auto& itemWtx : mapWallet) {
+            for (const auto& itemNd : itemWtx.second.mapSaplingNoteData)
+                nMaxWitnesses = std::max(nMaxWitnesses, itemNd.second.witnesses.size());
+            for (const auto& itemNd : itemWtx.second.mapSproutNoteData)
+                nMaxWitnesses = std::max(nMaxWitnesses, itemNd.second.witnesses.size());
+        }
+        if ((int64_t)nMaxWitnesses > nWitnessCacheSize) {
+            LogPrintf("LoadWallet: repairing witness cache size %d -> %d\n",
+                      nWitnessCacheSize, nMaxWitnesses);
+            nWitnessCacheSize = nMaxWitnesses;
+        }
+    }
+
     uiInterface.LoadWallet(this);
 
     return DB_LOAD_OK;

--- a/src/zmq/zmqpublishnotifier.h
+++ b/src/zmq/zmqpublishnotifier.h
@@ -13,7 +13,7 @@ class CBlockIndex;
 class CZMQAbstractPublishNotifier : public CZMQAbstractNotifier
 {
 private:
-    uint32_t nSequence; //! upcounting per message sequence number
+    uint32_t nSequence{0}; //! upcounting per message sequence number
 
 public:
 


### PR DESCRIPTION
Adds regtest flags for controlling network-upgrade activation and fixes a set of independent daemon defects. All changes are non-consensus; the ten commits are self-contained and reviewable individually.

### Regtest activation controls

Regtest defaults every network upgrade to `NO_ACTIVATION_HEIGHT`, so tests need a way to opt in per upgrade:

- `-ponactivation=<height>` sets the PON activation height on regtest. Setting it high leaves regtest in PoW, where the coinbase pays the wallet and tests can fund themselves by mining; setting it low activates PON rules at that height, and a test can cross the activation boundary.
- `-acadiaactivation=<height>` activates the ACADIA upgrade (Sapling and Overwintered transactions) at the given height on regtest.
- `-nuparams` accepts an upgrade name or index in addition to a branch id. Several upgrades share a branch id, so the branch-id form cannot target them individually.

### Fixes

- **Sapling witness cache repaired on load.** A wallet holding an imported key could serialize witness caches whose recorded size disagrees with the vector, and the next start aborted in `DecrementNoteWitnesses`. The size is clamped to the actual cache on load.
- **AMQP notifier survives a transient inactive connection** instead of tearing down permanently on the first hiccup.
- **ZMQ publish-notifier sequence counter initialized.** The per-topic sequence number published on the wire started from uninitialized memory.
- **`getblockdeltas` no longer emits a duplicate `address` key** in its output objects.
- **Mining RPCs guard against a null coinbase script** (previously a null dereference when no wallet or miner address could supply one).
- **`-mineraddress` is honoured** when no other mining script is provided.
- **`-connect=0` means no automatic outbound connections**, matching upstream Bitcoin. Previously the value was treated as a hostname and dialed forever (and handed to the SOCKS proxy when one is configured). Manual `addnode` and inbound connections are unaffected; the option help documents the semantics.

No ordering relationship with other open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
