### PR TITLE
Harden fluxnode tx signature-failure handling on the block path

### DIFF
--- a/src/gtest/test_checktransaction.cpp
+++ b/src/gtest/test_checktransaction.cpp
@@ -9,6 +9,7 @@
 #include "main.h"
 #include "primitives/transaction.h"
 #include "consensus/validation.h"
+#include "fluxnode/fluxnode.h"
 #include "utiltest.h"
 
 extern ZCJoinSplit* params;
@@ -138,6 +139,35 @@ TEST(checktransaction_tests, bad_txns_vout_empty) {
     MockCValidationState state;
     EXPECT_CALL(state, DoS(10, false, REJECT_INVALID, "bad-txns-vout-empty", false)).Times(1);
     CheckTransactionWithoutProofVerification(tx, state);
+}
+
+// A fluxnode confirm tx whose signatures are stripped or corrupted must have its failure
+// reported as corruption-possible. The operator and benchmark signatures are excluded from the
+// tx hash (SER_GETHASH), so they are not committed to the txid or, transitively, to the block
+// hash: a relaying peer can strip them without changing either hash. If such a failure were
+// reported as an ordinary invalidity, the block-connect paths would permanently mark the honest
+// block hash BLOCK_FAILED_VALID, letting a peer poison a victim into permanently rejecting a
+// valid block. The two flags asserted here are what those paths consult to instead reject only
+// this copy, penalize the sender, and leave the index/txid re-requestable.
+TEST(checktransaction_tests, FluxnodeConfirmSignatureFailureIsCorruptionPossible) {
+    SelectParams(CBaseChainParams::MAIN);
+
+    CMutableTransaction mtx;
+    mtx.nVersion = FLUXNODE_TX_VERSION;
+    mtx.nType = FLUXNODE_CONFIRM_TX_TYPE;
+    mtx.collateralIn = COutPoint(uint256S("0000000000000000000000000000000000000000000000000000000000000001"), 0);
+    mtx.nUpdateType = INITIAL_CONFIRM;
+    mtx.benchmarkTier = CUMULUS;
+    mtx.ip = "1.2.3.4";
+    // Signatures left empty, modelling a peer that stripped them in transit.
+
+    CTransaction tx(mtx);
+
+    CValidationState state;
+    EXPECT_FALSE(CheckTransactionWithoutProofVerification(tx, state));
+    EXPECT_EQ(state.GetRejectReason(), "bad-txns-fluxnode-tx-invalid-signature");
+    EXPECT_TRUE(state.CorruptionPossible());
+    EXPECT_TRUE(state.IsFluxnodeTxSignatureFailure());
 }
 
 TEST(checktransaction_tests, BadTxnsOversize) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1789,11 +1789,21 @@ bool CheckTransactionWithoutProofVerification(const CTransaction& tx, CValidatio
         }
 
         if (!CheckFluxnodeTxSignatures(tx)) {
-            // Signature is not committed to txid (excluded via SER_GETHASH), so signature failures
-            // should not blacklist by txid - another peer may send valid signature for same txid
+            // The operator and benchmark signatures are excluded from the tx hash (SER_GETHASH),
+            // so they are not committed to the txid or, transitively, to the block hash. A relaying
+            // peer can therefore strip or corrupt them without changing either hash. Two consequences
+            // must be defended against:
+            //   - Relay: do not blacklist the txid on a signature failure - another peer may carry a
+            //     validly-signed copy of the same txid (recentRejects carve-out keys off this flag).
+            //   - Block: do not permanently mark the block hash invalid on a signature failure -
+            //     otherwise a peer racing an honest block relay can poison the victim's index and
+            //     make it permanently reject the honest block hash. Set corruptionIn=true so the
+            //     block-connect paths reject this copy and penalize the sender without marking the
+            //     index, allowing an honestly-signed copy to be re-requested and accepted. This
+            //     mirrors the vchBlockSig/PON-block-signature handling in ContextualCheckBlock.
             state.SetFluxnodeTxSignatureFailure();
             return state.DoS(10, error("CheckTransaction(): Is Fluxnode Tx, invalid signatures"),
-                             REJECT_INVALID, "bad-txns-fluxnode-tx-invalid-signature");
+                             REJECT_INVALID, "bad-txns-fluxnode-tx-invalid-signature", true);
         }
 
         if (tx.nType == FLUXNODE_CONFIRM_TX_TYPE) {


### PR DESCRIPTION
Fluxnode operator and benchmark signatures are excluded from the transaction hash (`SER_GETHASH`) and so are not committed to the block hash. On the block-validation path, a signature-verification failure was reported as an ordinary invalidity, which marks the block index permanently invalid (`BLOCK_FAILED_VALID`).

This aligns the block path with the handling the block signature (`vchBlockSig` / PON) and the tx-relay path already use: a signature failure now sets corruption-possible state, so the block-connect paths reject the offending copy and penalize the sender without permanently marking the block hash — a correctly-signed copy of the same hash can still be validated and accepted. One change covers both the operator and benchmark signatures, since both route through `CheckFluxnodeTxSignatures`.

Adds a regression test asserting the signature failure is flagged corruption-possible.

Verification: unit test (fails without the change, passes with it) plus the full gtest suite. Behavioural recovery across peers is covered at the unit/code level here; end-to-end multi-node coverage will follow with the regtest testbed work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)