### PR TITLE
Keep the CachedWitnessesCleanIndex reorg-decrements below the chain tip

### DIFF
--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -1442,7 +1442,13 @@ TEST(WalletTests, CachedWitnessesCleanIndex) {
         EXPECT_EQ(sproutAnchors.back(), anchors.first);
         EXPECT_EQ(saplingAnchors.back(), anchors.second);
 
-        if ((i == 5) || (i == 50)) {
+        // Decrement at two heights strictly below the chain tip. The wallet's
+        // witnesses sit at the tip height (numBlocks - 1), so a reorg-decrement
+        // below it is a no-op that must leave the cache and the final anchor
+        // untouched. The deeper point is derived from WITNESS_CACHE_SIZE (which
+        // scales with MAX_REORG_LENGTH) rather than a literal, so it cannot land
+        // on the tip when the cache is small.
+        if ((i == 5) || (i == WITNESS_CACHE_SIZE - 1)) {
             // Pretend a reorg happened that was recorded in the block files
             {
                 wallet.DecrementNoteWitnesses(&(indices[i]));


### PR DESCRIPTION
`WalletTests.CachedWitnessesCleanIndex` fails on master. The test asserts that a reorg recorded in the block files leaves the witness cache and the final anchor untouched — which only holds when the decrement height is strictly below the chain tip, because `DecrementNoteWitnesses` touches any note whose `witnessHeight` is at or below the decremented height.

The test decrements at heights 5 and 50. With `MAX_REORG_LENGTH = 40`, the test chain is `WITNESS_CACHE_SIZE + 10 = 51` blocks, so height 50 is the tip: the second decrement pops the live witness and the assertions fail.

The deeper decrement height is now derived from `WITNESS_CACHE_SIZE` (which scales with `MAX_REORG_LENGTH`) rather than a literal, so it stays below the tip regardless of the reorg-length constant.

Verified: full flux-gtest suite on this branch is green (231/231), including the previously-failing test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)